### PR TITLE
Support set entrypoint lb annotations

### DIFF
--- a/controllers/clustermanagementaddon_controller.go
+++ b/controllers/clustermanagementaddon_controller.go
@@ -273,7 +273,7 @@ func (c *ClusterManagementAddonReconciler) ensureEntrypoint(config *proxyv1alpha
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   config.Spec.ProxyServer.Namespace,
 				Name:        config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Name,
-				Annotations: config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Annotations,
+				Annotations: getAnnotation(config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Annotations),
 			},
 			Spec: corev1.ServiceSpec{
 				Selector: map[string]string{
@@ -487,4 +487,22 @@ func getPEMCertExpireTime(pemBytes []byte) *metav1.Time {
 		return nil
 	}
 	return &metav1.Time{Time: cert.NotAfter}
+}
+
+func getAnnotation(list []proxyv1alpha1.AnnotationVar) map[string]string {
+	if len(list) == 0 {
+		return nil
+	}
+	annotation := make(map[string]string, len(list))
+	for _, v := range list {
+		key := v.Key
+		if len(key) == 0 {
+			continue
+		}
+		if len(key) > 63 {
+			key = key[:63]
+		}
+		annotation[key] = v.Value
+	}
+	return annotation
 }

--- a/controllers/clustermanagementaddon_controller.go
+++ b/controllers/clustermanagementaddon_controller.go
@@ -271,8 +271,9 @@ func (c *ClusterManagementAddonReconciler) ensureEntrypoint(config *proxyv1alpha
 	if config.Spec.ProxyServer.Entrypoint.Type == proxyv1alpha1.EntryPointTypeLoadBalancerService {
 		proxyService := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: config.Spec.ProxyServer.Namespace,
-				Name:      config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Name,
+				Namespace:   config.Spec.ProxyServer.Namespace,
+				Name:        config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Name,
+				Annotations: config.Spec.ProxyServer.Entrypoint.LoadBalancerService.Annotations,
 			},
 			Spec: corev1.ServiceSpec{
 				Selector: map[string]string{

--- a/hack/crd/bases/proxy.open-cluster-management.io_managedproxyconfigurations.yaml
+++ b/hack/crd/bases/proxy.open-cluster-management.io_managedproxyconfigurations.yaml
@@ -165,6 +165,13 @@ spec:
                         description: '`loadBalancerService` points to a load-balancer
                           typed service in the hub cluster.'
                         properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: annoations is the annoations of the load-balancer
+                              service. if the service use internal-ip, should have
+                              some annotations.
+                            type: object
                           name:
                             default: proxy-agent-entrypoint
                             description: '`name` is the name of the load-balancer

--- a/hack/crd/bases/proxy.open-cluster-management.io_managedproxyconfigurations.yaml
+++ b/hack/crd/bases/proxy.open-cluster-management.io_managedproxyconfigurations.yaml
@@ -166,12 +166,25 @@ spec:
                           typed service in the hub cluster.'
                         properties:
                           annotations:
-                            additionalProperties:
-                              type: string
-                            description: annoations is the annoations of the load-balancer
-                              service. if the service use internal-ip, should have
-                              some annotations.
-                            type: object
+                            description: 'Annotations is the annoations of the load-balancer
+                              service. This is for allowing customizing service using
+                              vendor-specific extended annotations such as: - service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type:
+                              "intranet" - service.beta.kubernetes.io/azure-load-balancer-internal:
+                              true'
+                            items:
+                              description: AnnotationVar list of annotation variables
+                                to set in the LB Service.
+                              properties:
+                                key:
+                                  description: Key is the key of annotation
+                                  type: string
+                                value:
+                                  description: Value is the value of annotation
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            type: array
                           name:
                             default: proxy-agent-entrypoint
                             description: '`name` is the name of the load-balancer

--- a/pkg/apis/proxy/v1alpha1/managedproxyconfiguration_types.go
+++ b/pkg/apis/proxy/v1alpha1/managedproxyconfiguration_types.go
@@ -245,10 +245,24 @@ type EntryPointLoadBalancerService struct {
 	// +kubebuilder:default=proxy-agent-entrypoint
 	Name string `json:"name"`
 
-	// annoations is the annoations of the load-balancer service.
-	// if the service use internal-ip, should have some annotations.
+	// Annotations is the annoations of the load-balancer service.
+	// This is for allowing customizing service using vendor-specific extended annotations such as:
+	// - service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type: "intranet"
+	// - service.beta.kubernetes.io/azure-load-balancer-internal: true
 	// +optional
-	Annotations map[string]string `json:"annotations"`
+	Annotations []AnnotationVar `json:"annotations,omitempty"`
+}
+
+// AnnotationVar list of annotation variables to set in the LB Service.
+type AnnotationVar struct {
+	// Key is the key of annotation
+	// +kubebuilder:validation:Required
+	// +required
+	Key string `json:"key"`
+
+	// Value is the value of annotation
+	// +optional
+	Value string `json:"value,omitempty"`
 }
 
 // EntryPointHostname references a fixed hostname.

--- a/pkg/apis/proxy/v1alpha1/managedproxyconfiguration_types.go
+++ b/pkg/apis/proxy/v1alpha1/managedproxyconfiguration_types.go
@@ -244,6 +244,11 @@ type EntryPointLoadBalancerService struct {
 	// +optional
 	// +kubebuilder:default=proxy-agent-entrypoint
 	Name string `json:"name"`
+
+	// annoations is the annoations of the load-balancer service.
+	// if the service use internal-ip, should have some annotations.
+	// +optional
+	Annotations map[string]string `json:"annotations"`
 }
 
 // EntryPointHostname references a fixed hostname.


### PR DESCRIPTION
Signed-off-by: champly <champly@outlook.com>

In some situation, lb which have internal ip for secrity, will set lb annotation, such as:
``` yaml
service.beta.kubernetes.io/alibaba-cloud-loadbalancer-address-type: "intranet" // for alibaba cloud.
service.beta.kubernetes.io/azure-load-balancer-internal: true // for azure cloud.
cloud.google.com/load-balancer-type: "Internal" // for google cloud.
```