### PR TITLE
Fix proxy-agent image to  proxyConfig.Spec.ProxyAgent.Image

### DIFF
--- a/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
+++ b/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
@@ -9,7 +9,7 @@ spec:
     signer:
       type: SelfSigned
   proxyServer:
-    image: {{ .Values.registry }}/{{ .Values.proxyServerImage }}:{{ .Values.tag }}
+    image: {{ .Values.proxyServerImage }}
     namespace: {{ .Release.Namespace }}
     entrypoint:
       {{- if .Values.proxyServer.entrypointAddress }}
@@ -23,4 +23,4 @@ spec:
       type: PortForward
       {{- end }}
   proxyAgent:
-    image: {{ .Values.registry }}/{{ .Values.proxyAgentImage }}:{{ .Values.tag }}
+    image: {{ .Values.proxyAgentImage }}

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -12,8 +12,8 @@ replicas: 1
 
 spokeAddonNamespace: "open-cluster-management-cluster-proxy"
 
-proxyServerImage: cluster-proxy
-proxyAgentImage: cluster-proxy
+proxyServerImage: quay.io/open-cluster-management/cluster-proxy:v0.1.4
+proxyAgentImage: quay.io/open-cluster-management/cluster-proxy:v0.1.4
 
 proxyServer:
   entrypointLoadBalancer: false

--- a/pkg/proxyagent/agent/agent.go
+++ b/pkg/proxyagent/agent/agent.go
@@ -141,6 +141,7 @@ func GetClusterProxyValueFunc(runtimeClient client.Client, nativeClient kubernet
 			"registry":                   registry,
 			"image":                      image,
 			"tag":                        tag,
+			"proxyAgentImage":            proxyConfig.Spec.ProxyAgent.Image,
 			"replicas":                   proxyConfig.Spec.ProxyAgent.Replicas,
 			"base64EncodedCAData":        base64.StdEncoding.EncodeToString(caCertData),
 			"serviceEntryPoint":          serviceEntryPoint,

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccount: cluster-proxy
       containers:
         - name: proxy-agent
-          image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag }}
+          image: {{ .Values.proxyAgentImage }}
           imagePullPolicy: IfNotPresent
           command:
             - /proxy-agent

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -13,6 +13,8 @@ image: cluster-proxy
 # Image tag
 tag: v0.1.3
 
+proxyAgentImage: quay.io/open-cluster-management/cluster-proxy:v0.1.4
+
 # Number of replicas
 replicas: 1
 


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

The inconsistent point right now is:

For proxy-server we use `config.Spec.ProxyServer.Image` as it's image.

https://github.com/open-cluster-management-io/cluster-proxy/blob/58c7d9318303cc47b6a9cd58779685e539df5430/pkg/proxyserver/controllers/manifests.go#L114

But for proxy-agent we are using the same image as addon-agent is using.

https://github.com/open-cluster-management-io/cluster-proxy/blob/58c7d9318303cc47b6a9cd58779685e539df5430/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml#L34

The PR is to allow users to use entire different anp(proxy-server & proxy-agent) images.