### PR TITLE
Fix ownerreference bug caused by addon-framework

### DIFF
--- a/charts/cluster-proxy/templates/clusterrole.yaml
+++ b/charts/cluster-proxy/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - clustermanagementaddons
       - managedclusteraddons
       - clustermanagementaddons/status
+      - clustermanagementaddons/finalizers
       - managedclusteraddons/status
     verbs:
       - '*'


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

This PR is related to: https://github.com/open-cluster-management-io/cluster-proxy/issues/71

But this ownerReference bug is not caused by cluster-proxy itself, but by addon-framework:

https://github.com/open-cluster-management-io/addon-framework/blob/f3917ca3a39cd63ede2bfbf63988c463c21ded2b/pkg/addonmanager/controllers/clustermanagement/controller.go#L111

In addon-framework,  we set `clustermanagementAddon` as ownerReference to our addon. So this permission also need added in the clusterrole.

