### PR TITLE
Revert "Bugfix: Fixes cluster-proxy addon agent image rendering"

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /etc/tls
               readOnly: true
         - name: addon-agent
-          image: {{ .Values.proxyAgentImage }}
+          image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag }}
           imagePullPolicy: IfNotPresent
           command:
             - /agent


### PR DESCRIPTION
`--agent-image-name` should be honored