### PR TITLE
Chore: Homogenize chart version

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -36,9 +36,6 @@ jobs:
       - name: verify chart version
         run: |
           cat ./charts/cluster-proxy/Chart.yaml  | grep -q 'version: ${{ env.TRIMED_RELEASE_VERSION }}'
-          cat ./charts/cluster-proxy/values.yaml | grep -q 'tag: ${{ env.RELEASE_VERSION }}'
-          cat ./charts/cluster-proxy/values.yaml | grep -q 'proxyServerImage: quay.io/open-cluster-management/cluster-proxy:${{ env.RELEASE_VERSION }}'
-          cat ./charts/cluster-proxy/values.yaml | grep -q 'proxyAgentImage: quay.io/open-cluster-management/cluster-proxy:${{ env.RELEASE_VERSION }}'
     outputs:
       MAJOR_RELEASE_VERSION: ${{ env.MAJOR_RELEASE_VERSION }}
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
+++ b/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
@@ -9,7 +9,7 @@ spec:
     signer:
       type: SelfSigned
   proxyServer:
-    image: {{ .Values.proxyServerImage }}:{{ .Values.tag }}
+    image: {{ .Values.proxyServerImage }}:{{ .Values.tag | default (print "v" .Chart.Version) }}
     namespace: {{ .Release.Namespace }}
     entrypoint:
       {{- if .Values.proxyServer.entrypointAddress }}
@@ -24,4 +24,4 @@ spec:
       {{- end }}
       port: {{ .Values.proxyServer.port }}
   proxyAgent:
-    image: {{ .Values.proxyAgentImage }}:{{ .Values.tag }}
+    image: {{ .Values.proxyAgentImage }}:{{ .Values.tag | default (print "v" .Chart.Version) }}

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccount: cluster-proxy
       containers:
         - name: manager
-          image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag }}
+          image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}
           imagePullPolicy: IfNotPresent
           command:
             - /manager

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -5,7 +5,7 @@ registry: quay.io/open-cluster-management
 image: cluster-proxy
 
 # Image tag
-tag: v0.2.2
+tag:
 
 # Number of replicas
 replicas: 1


### PR DESCRIPTION
from this pull on, we can minimize the version management of helm charts via bumping merely the `Chart.yaml` file. 