### PR TITLE
Update makefile for go1.18

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.18'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/cluster-proxy/cluster-proxy/go'
 defaults:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.18'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/cluster-proxy/cluster-proxy/go'
 defaults:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.18'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/cluster-proxy/cluster-proxy/go'
   GITHUB_REF: ${{ github.ref }}

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

releated link: https://go.dev/doc/go1.18

> go get no longer builds or installs packages in module-aware mode.