### PR TITLE
Fix: requeue when managedproxyconfiguration not found.

### DIFF
--- a/pkg/proxyserver/controllers/clustermanagementaddon_controller.go
+++ b/pkg/proxyserver/controllers/clustermanagementaddon_controller.go
@@ -130,10 +130,6 @@ func (c *ClusterManagementAddonReconciler) Reconcile(ctx context.Context, reques
 	// get the related proxy configuration
 	config := &proxyv1alpha1.ManagedProxyConfiguration{}
 	if err := c.Client.Get(ctx, types.NamespacedName{Name: managedProxyConfigurationName}, config); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Cannot find proxy-configuration", "name", managedProxyConfigurationName)
-			return reconcile.Result{}, nil
-		}
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/proxyserver/operator/eventhandler/proxyconfiguration_event.go
+++ b/pkg/proxyserver/operator/eventhandler/proxyconfiguration_event.go
@@ -50,12 +50,11 @@ func findRelatedAddon(c client.Client, cfgName string, limitingInterface workque
 	}
 	for _, addon := range list.Items {
 		if addon.Name == common.AddonName {
-			if addon.Spec.AddOnConfiguration.CRName == cfgName {
-				req := reconcile.Request{}
-				req.Namespace = addon.Namespace
-				req.Name = addon.Name
-				limitingInterface.Add(req)
-			}
+			// There is only one clustermanagemetnaddon for "cluster-proxy", and the config file of cluster-proxy must be a managedproxyconfiguration. So we don't need to check whether "cluster-proxy" addon match the cfg.
+			req := reconcile.Request{}
+			req.Namespace = addon.Namespace
+			req.Name = addon.Name
+			limitingInterface.Add(req)
 		}
 	}
 }


### PR DESCRIPTION
This PR is to fix the issue when the first reconcile failed because `managedproxyconfiguration` not found.