### PR TITLE
workload partitioning for proxy-agent in managed cluster

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -22,8 +22,9 @@ spec:
     metadata:
       annotations:
       {{- with .Values.agentDeploymentAnnotations }}
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | indent 2 }}
       {{- end }}
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         open-cluster-management.io/addon: cluster-proxy
         proxy.open-cluster-management.io/component-name: proxy-agent


### PR DESCRIPTION
similar to [service-proxy](https://github.com/stolostron/cluster-proxy-addon/pull/98), let the pod to pin to reserved cores. 

JIRA: OCPBUGS-11604

/cc @xuezhaojun 