### PR TITLE
Remove "debug" when submit charts.

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -121,7 +121,6 @@ jobs:
       - name: submit charts to OCM chart repo
         uses: actions/github-script@v6
         with:
-          debug: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |
             try {


### PR DESCRIPTION
The `ACTIONS_RUNNER_DEBUG` is not defined in the setting.

And in this PR of github-script, it replaced `getInput("debug")` with `getBooleanInput("debug")` which can't handle `undefined`.

https://github.com/actions/github-script/commit/8d9f8fc050d038eac46e34e317ca8dc9b3a83e71#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d

That is why we have error:

```
TypeError: Input does not meet YAML 1.2 "Core Schema" specification: debug
Error: Unhandled error: TypeError: Input does not meet YAML 1.2 "Core Schema" specification: debug
Support boolean input list: `true | True | TRUE | false | False | FALSE`
```