### PR TITLE
Fix: add finalizer permission to cluster-proxy.

### DIFF
--- a/charts/cluster-proxy/templates/clusterrole.yaml
+++ b/charts/cluster-proxy/templates/clusterrole.yaml
@@ -31,6 +31,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - addon.open-cluster-management.io
+    resources:
+      - managedclusteraddons/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
       - proxy.open-cluster-management.io
     resources:
       - managedproxyconfigurations


### PR DESCRIPTION
Fixes: https://github.com/open-cluster-management-io/ocm/issues/230

Error log:
```
E1008 07:15:14.237293 1 base_controller.go:159] "addon-deploy-controller" controller failed to sync "local-cluster/cluster-proxy", err: Operation cannot be fulfilled on managedclusteraddons.addon.open-cluster-management.io "cluster-proxy": the object has been modified; please apply your changes to the latest version and try again
E1008 07:15:14.247988 1 base_controller.go:159] "addon-deploy-controller" controller failed to sync "local-cluster/cluster-proxy", err: manifestworks.work.open-cluster-management.io "addon-cluster-proxy-deploy-0" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E1008
```