### PR TITLE
Fix the verify error of logger.

### DIFF
--- a/cmd/addon-agent/main.go
+++ b/cmd/addon-agent/main.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	"open-cluster-management.io/addon-framework/pkg/lease"
 	"open-cluster-management.io/cluster-proxy/pkg/common"
 	"open-cluster-management.io/cluster-proxy/pkg/util"
@@ -31,7 +31,7 @@ const envKeyPodNamespace = "POD_NAMESPACE"
 
 func main() {
 
-	logger := klogr.New()
+	logger := textlogger.NewLogger(textlogger.NewConfig())
 	klog.SetOutput(os.Stdout)
 	klog.InitFlags(flag.CommandLine)
 	flag.StringVar(&hubKubeconfig, "hub-kubeconfig", "",

--- a/cmd/addon-manager/main.go
+++ b/cmd/addon-manager/main.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	addonutil "open-cluster-management.io/addon-framework/pkg/utils"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -73,7 +73,7 @@ func main() {
 	var agentInstallAll bool
 	var enableKubeApiProxy bool
 
-	logger := klogr.New()
+	logger := textlogger.NewLogger(textlogger.NewConfig())
 	klog.SetOutput(os.Stdout)
 	klog.InitFlags(flag.CommandLine)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":58080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
Fixes:

```
cmd/addon-agent/main.go:34:12: SA1019: klogr.New is deprecated: this uses a custom, out-dated output format. Use textlogger.NewLogger instead. (staticcheck)
        logger := klogr.New()
                  ^
cmd/addon-manager/main.go:76:12: SA1019: klogr.New is deprecated: this uses a custom, out-dated output format. Use textlogger.NewLogger instead. (staticcheck)
        logger := klogr.New()
```

Somehow the previous PR bypassed this check.