### PR TITLE
Fix LB type proxy server setup in chart

### DIFF
--- a/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
+++ b/charts/cluster-proxy/templates/managedproxyconfiguration.yaml
@@ -17,7 +17,7 @@ spec:
       type: Hostname
       hostname:
         value: {{ .Values.proxyServer.entrypointAddress }}
-      {{- else if .Values.entrypointLoadBalancer }}
+      {{- else if .Values.proxyServer.entrypointLoadBalancer }}
       type: LoadBalancerService
       loadBalancerService: {}
       {{- else  }}


### PR DESCRIPTION
Using values incorrectly 

https://github.com/open-cluster-management-io/cluster-proxy/blob/main/charts/cluster-proxy/values.yaml#L18-L21