### PR TITLE
Use default rollingout strategy.

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -13,11 +13,6 @@ spec:
     matchLabels:
       open-cluster-management.io/addon: cluster-proxy
       proxy.open-cluster-management.io/component-name: proxy-agent
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
   template:
     metadata:
       annotations:


### PR DESCRIPTION
We want to keep at least one running pod, the current configuration doesn't fit.