### PR TITLE
Set failureThreshold to 3 for improved stability

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -60,7 +60,7 @@ spec:
               scheme: HTTP
               port: 8888
             initialDelaySeconds: 10
-            failureThreshold: 1
+            failureThreshold: 3
             periodSeconds: 10
           env:
             {{- if .Values.proxyConfig.HTTP_PROXY }}


### PR DESCRIPTION
addon-agent restarts due to a connection error: `"cannot connect once" err="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:8091: connect: connection refused\""`