### PR TITLE
Revert "Set failureThreshold to 3 for improved stability"

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -60,7 +60,7 @@ spec:
               scheme: HTTP
               port: 8888
             initialDelaySeconds: 10
-            failureThreshold: 3
+            failureThreshold: 1
             periodSeconds: 10
           env:
             {{- if .Values.proxyConfig.HTTP_PROXY }}


### PR DESCRIPTION
Reverts open-cluster-management-io/cluster-proxy#214

The `failureThreshould` set to `1` on purpose:  https://github.com/open-cluster-management-io/addon-framework/blob/d787e984afdabb410ac6e93aa703e836c367031b/pkg/utils/config_checker.go#L76