### PR TITLE
Revert "Set failureThreshold to 3 for improved stability (#214)"

### DIFF
--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -60,7 +60,7 @@ spec:
               scheme: HTTP
               port: 8888
             initialDelaySeconds: 10
-            failureThreshold: 3
+            failureThreshold: 1
             periodSeconds: 10
           env:
             {{- if .Values.proxyConfig.HTTP_PROXY }}


### PR DESCRIPTION
This reverts commit ea838c05e778055106ce7c7f15ff6fa2457dcc71.

The `failureThreshould` set to `1` on purpose:  https://github.com/open-cluster-management-io/addon-framework/blob/d787e984afdabb410ac6e93aa703e836c367031b/pkg/utils/config_checker.go#L76