### PR TITLE
Upgrade Go version to 1.24

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -9,10 +9,10 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22'
-  GO_REQUIRED_MIN_VERSION: ''
+  GO_VERSION: "1.24"
+  GO_REQUIRED_MIN_VERSION: ""
   GITHUB_REF: ${{ github.ref }}
-  CHART_NAME: 'cluster-proxy'
+  CHART_NAME: "cluster-proxy"
 
 jobs:
   env:
@@ -40,7 +40,7 @@ jobs:
   upload:
     name: upload
     runs-on: ubuntu-latest
-    needs: [ env ]
+    needs: [env]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   GO_REQUIRED_MIN_VERSION: ""
 
 jobs:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   GO_REQUIRED_MIN_VERSION: ""
 
 jobs:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 env:
   # Common versions
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   GO_REQUIRED_MIN_VERSION: ""
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: "cluster-proxy"

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/cluster-proxy
 
-go 1.23.6
+go 1.24
 
 require (
 	github.com/onsi/ginkgo/v2 v2.17.1


### PR DESCRIPTION
This PR upgrades the Go version to 1.24.

Changes include:
- Updated go.mod to use Go 1.24
- Updated Dockerfile to use Go 1.24 builder image
- Updated GitHub workflow files to use Go 1.24

Verified with make build - all builds successfully with Go 1.24.