### PR TITLE
docs: update helm repository URL and namespace in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The overall architecture is shown below:
 1. Add the OCM Helm repository:
 
 ```shell
-helm repo add ocm https://openclustermanagement.blob.core.windows.net/releases/
+helm repo add ocm https://open-cluster-management.io/helm-charts/
 helm repo update
 helm search repo ocm/cluster-proxy
 ```
@@ -67,7 +67,7 @@ helm install \
 3. Verify the installation:
 
 ```shell
-kubectl -n open-cluster-management-cluster-proxy get pod
+kubectl get pods -n open-cluster-management-addon
 ```
 
 Expected output:


### PR DESCRIPTION
## Summary
Update README.md installation instructions to use the correct Helm repository URL and namespace for the cluster-proxy component.

## Changes
- Update Helm repository URL from Azure blob storage to the official OCM Helm charts repository
- Correct the kubectl namespace in verification commands from `open-cluster-management-cluster-proxy` to `open-cluster-management-addon`

## Test plan
- [ ] Documentation changes reviewed for accuracy
- [ ] Installation instructions tested with updated commands
- [ ] Namespace verification confirmed

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [ ] Breaking changes documented (N/A)

🤖 Generated with [Claude Code](https://claude.ai/code)