### PR TITLE
Fix cluster-proxy service-proxy failback to hub authentication if managed cluster authentication fails

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -365,8 +366,12 @@ func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Requ
 	// try managed cluster authentication first
 	managedClusterResp, managedClusterAuthenticated, err := s.managedClusterAuthenticator.AuthenticateToken(ctx, token)
 	if err != nil {
-		logger.Error(err, "managed cluster authentication failed")
-		return fmt.Errorf("managed cluster authentication failed: %v", err)
+		if errors.Is(err, ErrTokenNotAuthenticated) {
+			logger.V(4).Info("managed cluster token not authenticated, trying hub", "error", err)
+			managedClusterAuthenticated = false
+		} else {
+			return fmt.Errorf("managed cluster authentication failed: %v", err)
+		}
 	}
 
 	if managedClusterAuthenticated {
@@ -383,8 +388,13 @@ func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Requ
 		// try hub authentication
 		hubResp, hubAuthenticated, err := s.hubAuthenticator.AuthenticateToken(ctx, token)
 		if err != nil {
-			logger.Error(err, "hub cluster authentication failed")
-			return fmt.Errorf("authentication failed: managed cluster auth: not authenticated, hub cluster auth error: %v", err)
+			if errors.Is(err, ErrTokenNotAuthenticated) {
+				logger.V(4).Info("hub cluster token not authenticated", "error", err)
+				hubAuthenticated = false
+			} else {
+				logger.Error(err, "hub cluster authentication failed")
+				return fmt.Errorf("authentication failed: managed cluster auth: not authenticated, hub cluster auth error: %v", err)
+			}
 		}
 		logger.V(4).Info("hub cluster authentication result",
 			"authenticated", hubAuthenticated,

--- a/pkg/serviceproxy/token_authenticator.go
+++ b/pkg/serviceproxy/token_authenticator.go
@@ -2,6 +2,7 @@ package serviceproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -11,6 +12,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
+
+// ErrTokenNotAuthenticated is returned when a TokenReview explicitly rejects a
+// token (Status.Error is non-empty). Callers use errors.Is to distinguish this
+// from infrastructure errors (network, TLS, etc.).
+var ErrTokenNotAuthenticated = errors.New("token not authenticated")
 
 // tokenReviewAuthenticator implements authenticator.Token by calling the
 // Kubernetes TokenReview API against a specific cluster.
@@ -40,10 +46,11 @@ func (a *tokenReviewAuthenticator) AuthenticateToken(ctx context.Context, token 
 		"groups", tokenReview.Status.User.Groups,
 	)
 
+	if tokenReview.Status.Error != "" {
+		return nil, false, fmt.Errorf("%s TokenReview: %s: %w", a.name, tokenReview.Status.Error, ErrTokenNotAuthenticated)
+	}
+
 	if !tokenReview.Status.Authenticated {
-		if tokenReview.Status.Error != "" {
-			return nil, false, fmt.Errorf("%s TokenReview error: %s", a.name, tokenReview.Status.Error)
-		}
 		return nil, false, nil
 	}
 

--- a/pkg/serviceproxy/token_authenticator.go
+++ b/pkg/serviceproxy/token_authenticator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,9 +15,29 @@ import (
 )
 
 // ErrTokenNotAuthenticated is returned when a TokenReview explicitly rejects a
-// token (Status.Error is non-empty). Callers use errors.Is to distinguish this
-// from infrastructure errors (network, TLS, etc.).
+// token with a known authentication error. Callers use errors.Is to distinguish
+// this from infrastructure errors (network, TLS, etc.).
 var ErrTokenNotAuthenticated = errors.New("token not authenticated")
+
+// authRejectionPatterns contains substrings of TokenReview Status.Error that
+// indicate the token was rejected by the authenticator. Observed from:
+//   - Kubernetes v1.35: "invalid bearer token"
+//   - OpenShift 4.x:    "[invalid bearer token, token lookup failed]"
+var authRejectionPatterns = []string{
+	"invalid bearer token",
+}
+
+// isAuthRejection reports whether a TokenReview Status.Error indicates an
+// authentication rejection rather than an infrastructure failure.
+func isAuthRejection(statusError string) bool {
+	lower := strings.ToLower(statusError)
+	for _, pattern := range authRejectionPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
 
 // tokenReviewAuthenticator implements authenticator.Token by calling the
 // Kubernetes TokenReview API against a specific cluster.
@@ -47,7 +68,10 @@ func (a *tokenReviewAuthenticator) AuthenticateToken(ctx context.Context, token 
 	)
 
 	if tokenReview.Status.Error != "" {
-		return nil, false, fmt.Errorf("%s TokenReview: %s: %w", a.name, tokenReview.Status.Error, ErrTokenNotAuthenticated)
+		if isAuthRejection(tokenReview.Status.Error) {
+			return nil, false, fmt.Errorf("%s TokenReview: %s: %w", a.name, tokenReview.Status.Error, ErrTokenNotAuthenticated)
+		}
+		return nil, false, fmt.Errorf("%s TokenReview: %s", a.name, tokenReview.Status.Error)
 	}
 
 	if !tokenReview.Status.Authenticated {

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -2,6 +2,7 @@ package serviceproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -72,7 +73,7 @@ func TestTokenReviewAuthenticator_Unauthenticated(t *testing.T) {
 
 func TestProcessAuthentication_ManagedClusterToken(t *testing.T) {
 	s := &serviceProxy{
-		enableImpersonation:         true,
+		enableImpersonation: true,
 		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 			return &authenticator.Response{User: &user.DefaultInfo{Name: "mc-user"}}, true, nil
 		}),
@@ -303,6 +304,9 @@ func TestTokenReviewAuthenticator_StatusError(t *testing.T) {
 	if resp != nil {
 		t.Fatal("expected nil response")
 	}
+	if !errors.Is(err, ErrTokenNotAuthenticated) {
+		t.Fatalf("expected ErrTokenNotAuthenticated, got: %v", err)
+	}
 	if !strings.Contains(err.Error(), "Credentials are expired") {
 		t.Fatalf("expected Status.Error in error message, got: %v", err)
 	}
@@ -339,15 +343,14 @@ func TestProcessAuthentication_GetImpersonateTokenError(t *testing.T) {
 	}
 }
 
-func TestProcessAuthentication_ManagedClusterAuthError(t *testing.T) {
-	hubCalled := false
+func TestProcessAuthentication_ManagedClusterFatalError(t *testing.T) {
 	s := &serviceProxy{
 		enableImpersonation: true,
 		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 			return nil, false, fmt.Errorf("apiserver unreachable")
 		}),
 		hubAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			hubCalled = true
+			t.Fatal("hub authenticator should not be called for fatal managed cluster errors")
 			return nil, false, nil
 		}),
 	}
@@ -357,25 +360,61 @@ func TestProcessAuthentication_ManagedClusterAuthError(t *testing.T) {
 
 	err := s.processAuthentication(context.Background(), req)
 	if err == nil {
-		t.Fatal("expected error")
+		t.Fatal("expected fatal error when managed cluster auth has infrastructure failure")
 	}
-	if !strings.Contains(err.Error(), "managed cluster authentication failed") {
-		t.Fatalf("expected managed cluster error, got: %v", err)
+	if !strings.Contains(err.Error(), "apiserver unreachable") {
+		t.Fatalf("expected original error preserved, got: %v", err)
 	}
-	if hubCalled {
-		t.Fatal("hub authenticator should not be called when managed cluster auth errors")
+}
+
+func TestProcessAuthentication_OpenShiftTokenReviewError_FallsBackToHub(t *testing.T) {
+	s := &serviceProxy{
+		enableImpersonation: true,
+		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+			return nil, false, fmt.Errorf(
+				"managed cluster TokenReview: invalid bearer token, token lookup failed: %w",
+				ErrTokenNotAuthenticated,
+			)
+		}),
+		hubAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+			return &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name:   "kube:admin",
+					Groups: []string{"system:cluster-admins", "system:authenticated"},
+				},
+			}, true, nil
+		}),
+		getImpersonateTokenFunc: func() (string, error) {
+			return "fake-sa-token", nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	req.Header.Set("Authorization", "Bearer hub-only-token")
+
+	err := s.processAuthentication(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Header.Get("Impersonate-User") != "kube:admin" {
+		t.Fatalf("expected impersonate user 'kube:admin', got '%s'", req.Header.Get("Impersonate-User"))
+	}
+	if req.Header.Get("Authorization") != "Bearer fake-sa-token" {
+		t.Fatalf("expected authorization header to use impersonation token, got '%s'", req.Header.Get("Authorization"))
 	}
 }
 
 func TestProcessAuthentication_HubAuthError(t *testing.T) {
 	s := &serviceProxy{
 		enableImpersonation: true,
-		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			return nil, false, nil // not a managed cluster token
-		}),
-		hubAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			return nil, false, fmt.Errorf("hub apiserver timeout")
-		}),
+		managedClusterAuthenticator: authenticator.TokenFunc(
+			func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+				return nil, false, nil // not a managed cluster token
+			}),
+		hubAuthenticator: authenticator.TokenFunc(
+			func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+				return nil, false, fmt.Errorf("hub apiserver timeout")
+			}),
 	}
 
 	req, _ := http.NewRequest("GET", "https://example.com/api", nil)

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -282,19 +282,66 @@ func TestTokenReviewAuthenticator_APIError(t *testing.T) {
 	}
 }
 
-func TestTokenReviewAuthenticator_StatusError(t *testing.T) {
+func TestTokenReviewAuthenticator_StatusError_KnownRejection(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusError string
+	}{
+		{
+			name:        "Kubernetes: invalid bearer token",
+			statusError: "invalid bearer token",
+		},
+		{
+			name:        "OpenShift: invalid bearer token with token lookup failed",
+			statusError: "[invalid bearer token, token lookup failed]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &authenticationv1.TokenReview{
+					Status: authenticationv1.TokenReviewStatus{
+						Authenticated: false,
+						Error:         tt.statusError,
+					},
+				}, nil
+			})
+
+			authn := &tokenReviewAuthenticator{client: client, name: "test"}
+			resp, ok, err := authn.AuthenticateToken(context.Background(), "bad-token")
+			if err == nil {
+				t.Fatal("expected error when Status.Error is set")
+			}
+			if ok {
+				t.Fatal("expected authenticated=false")
+			}
+			if resp != nil {
+				t.Fatal("expected nil response")
+			}
+			if !errors.Is(err, ErrTokenNotAuthenticated) {
+				t.Fatalf("expected ErrTokenNotAuthenticated, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.statusError) {
+				t.Fatalf("expected Status.Error in error message, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestTokenReviewAuthenticator_StatusError_UnknownError(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, &authenticationv1.TokenReview{
 			Status: authenticationv1.TokenReviewStatus{
 				Authenticated: false,
-				Error:         "Credentials are expired",
+				Error:         "webhook authenticator connection reset",
 			},
 		}, nil
 	})
 
 	authn := &tokenReviewAuthenticator{client: client, name: "test"}
-	resp, ok, err := authn.AuthenticateToken(context.Background(), "expired-token")
+	resp, ok, err := authn.AuthenticateToken(context.Background(), "some-token")
 	if err == nil {
 		t.Fatal("expected error when Status.Error is set")
 	}
@@ -304,10 +351,10 @@ func TestTokenReviewAuthenticator_StatusError(t *testing.T) {
 	if resp != nil {
 		t.Fatal("expected nil response")
 	}
-	if !errors.Is(err, ErrTokenNotAuthenticated) {
-		t.Fatalf("expected ErrTokenNotAuthenticated, got: %v", err)
+	if errors.Is(err, ErrTokenNotAuthenticated) {
+		t.Fatal("unknown Status.Error should NOT be wrapped with ErrTokenNotAuthenticated")
 	}
-	if !strings.Contains(err.Error(), "Credentials are expired") {
+	if !strings.Contains(err.Error(), "webhook authenticator connection reset") {
 		t.Fatalf("expected Status.Error in error message, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- **Bug**: The service-proxy `processAuthentication` function returns immediately when the managed cluster `TokenReview` returns an error, never attempting hub authentication. This causes all hub-only users to receive "Unauthorized" when accessing managed cluster resources through the proxy.
- **Root cause**: Some Kubernetes distributions populate `TokenReview.Status.Error` for unrecognized tokens (unlike others which return `Authenticated: false` with no error). The `tokenReviewAuthenticator` surfaces this as a Go error, and `processAuthentication` treats any error from managed cluster auth as fatal — exiting before trying hub auth.
- **Fix**: Introduce an `ErrTokenNotAuthenticated` sentinel error. When a `TokenReview` explicitly rejects a token (`Status.Error` is non-empty), the error is wrapped with this sentinel. In `processAuthentication`, `errors.Is(err, ErrTokenNotAuthenticated)` distinguishes token rejection from infrastructure errors. Token rejections fall through to hub authentication; infrastructure errors remain fatal.

## Error Handling

| Scenario | Code Location | `err` value | `errors.Is(err, ErrTokenNotAuthenticated)` | Result |
|---|---|---|---|---|
| API call failed (network, TLS, etc.) | `token_authenticator.go:38-39` | plain error from `client.Create()` | `false` | Fatal, no fallback |
| Token rejected with `Status.Error` | `token_authenticator.go:49-51` | wraps `ErrTokenNotAuthenticated` sentinel | `true` | Fall through to hub |
| Token not recognized, no `Status.Error` | `token_authenticator.go:53-54` | `nil` | N/A | Fall through to hub |

The sentinel check is used in both auth paths: managed cluster (`service_proxy.go:369`) and hub (`service_proxy.go:391`).

## Impact

Any deployment where the managed cluster's Kubernetes distribution sets `TokenReview.Status.Error` for invalid tokens. Affects proxied requests (console access, pod logs, etc.) for users authenticated only on the hub.

## Changes

- `pkg/serviceproxy/token_authenticator.go`: Define `ErrTokenNotAuthenticated` sentinel error. Wrap it via `fmt.Errorf("%w")` when `TokenReview.Status.Error` is non-empty. Infrastructure errors from `client.Create()` are returned as-is.
- `pkg/serviceproxy/service_proxy.go`: Use `errors.Is(err, ErrTokenNotAuthenticated)` to distinguish token rejection (fall through to hub auth) from infrastructure errors (fatal). Applied consistently to both managed cluster and hub authentication paths.
- `pkg/serviceproxy/token_authenticator_test.go`: Updated and added tests covering:
  - `TestTokenReviewAuthenticator_StatusError` — verifies `Status.Error` produces an error wrapping `ErrTokenNotAuthenticated`
  - `TestProcessAuthentication_ManagedClusterFatalError` — infrastructure error is fatal, hub auth not attempted
  - `TestProcessAuthentication_OpenShiftTokenReviewError_FallsBackToHub` — token rejection falls through to hub auth with correct impersonation
  - `TestProcessAuthentication_HubAuthError` — hub infrastructure error is fatal with error preserved

## Test plan

- [x] Unit tests pass (`go test ./pkg/serviceproxy/`)
- [x] Verified on live environment: deployed to managed cluster, confirmed hub user can access resources through cluster-proxy (previously returned 401 Unauthorized)
- [x] Verify no regression for managed-cluster-native tokens (tokens recognized by the managed cluster should still work without hitting hub auth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow so certain managed-cluster authentication rejections are treated as non-fatal and correctly fall back to hub token review; other hub failures remain fatal.
  * Clarified error handling to preserve original failure context when authentication is fatal.

* **Tests**
  * Expanded tests to cover known rejection patterns, unknown error cases, fatal vs non-fatal classification, fallback behavior, and correct impersonation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/cluster-proxy/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->