### PR TITLE
:bug: Fix arm64 image builds

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -35,7 +35,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images
       - name: push
         run: |

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images
       - name: push
         run: |

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ client-gen:
 
 images:
 	$(CONTAINER_ENGINE) build \
+		$(IMAGE_BUILD_EXTRA_FLAGS) \
 		-f cmd/Dockerfile \
 		--build-arg ADDON_AGENT_IMAGE_NAME=$(IMAGE_REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_TAG) \
 		-t $(IMAGE_REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_TAG) .

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,22 +1,26 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 WORKDIR /workspace
 
+ARG TARGETOS=linux
+ARG TARGETARCH
 ARG APISERVER_NETWORK_PROXY_VERSION=0.30.2
 ARG KUBECTL_VERSION=v1.30.2
 ARG ADDON_AGENT_IMAGE_NAME
 
 # Build Apiserver-network-proxy binaries
-RUN wget https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v${APISERVER_NETWORK_PROXY_VERSION}.tar.gz \
+RUN set -eux; \
+      export GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABLED=0; \
+      wget https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/refs/tags/v${APISERVER_NETWORK_PROXY_VERSION}.tar.gz \
       && tar xzvf v${APISERVER_NETWORK_PROXY_VERSION}.tar.gz \
       && cd apiserver-network-proxy-${APISERVER_NETWORK_PROXY_VERSION} \
-      && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /workspace/proxy-server ./cmd/server/ \
-      && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /workspace/proxy-agent ./cmd/agent/ \
-      && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /workspace/proxy-test-client ./cmd/test-client/ \
-      && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /workspace/proxy-test-server ./cmd/test-server/ \
+      && go build -o /workspace/proxy-server ./cmd/server/ \
+      && go build -o /workspace/proxy-agent ./cmd/agent/ \
+      && go build -o /workspace/proxy-test-client ./cmd/test-client/ \
+      && go build -o /workspace/proxy-test-server ./cmd/test-server/ \
       && cd /workspace \
-      && curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      && curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${GOOS}/${GOARCH}/kubectl" \
       && chmod a+x kubectl
 
 # Copy the Go Modules manifests
@@ -31,18 +35,18 @@ COPY cmd/ cmd/
 COPY pkg pkg/
 
 # Build addons
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o agent cmd/addon-agent/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a \
+RUN set -eux; \
+      export GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABLED=0; \
+      go build -a -o agent cmd/addon-agent/main.go; \
+      go build -a \
         -ldflags="-X 'open-cluster-management.io/cluster-proxy/pkg/config.AgentImageName=${ADDON_AGENT_IMAGE_NAME}'" \
-        -o manager cmd/addon-manager/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o cluster-proxy cmd/cluster-proxy/main.go
+        -o manager cmd/addon-manager/main.go; \
+      go build -a -o cluster-proxy cmd/cluster-proxy/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Use Alpine as a minimal base image to package the static binaries.
 FROM alpine:3.21
 
 WORKDIR /
-RUN apk add libc6-compat
 COPY --from=builder /workspace/kubectl /workspace/proxy-server /workspace/proxy-agent /workspace/proxy-test-client /workspace/proxy-test-server ./
 COPY --from=builder /workspace/agent /workspace/manager ./
 COPY --from=builder /workspace/cluster-proxy ./


### PR DESCRIPTION
## Summary

Build the cluster-proxy image with the requested target architecture so the arm64 variant contains an arm64 `/cluster-proxy` binary.

## Related issue(s)

Fixes #292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Docker image build pipeline to better support multiple processor architectures.
  * Updated build system configuration to use improved architecture targeting during image builds.
  * Streamlined cross-platform compilation process in Docker image construction.
  * Refined multi-architecture build handling in the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->