### PR TITLE
:seedling: chore: upgrade to go 1.26

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   GO_REQUIRED_MIN_VERSION: ""
 
 jobs:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   GO_REQUIRED_MIN_VERSION: ""
 
 jobs:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 env:
   # Common versions
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   GO_REQUIRED_MIN_VERSION: ""
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: "cluster-proxy"

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/cluster-proxy
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for e2e test binary
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Upgrades Go version from 1.25 to 1.26.

Changes:
- `go.mod` — go directive updated to 1.26.0
- `.github/workflows/go-presubmit.yml` — GO_VERSION updated to 1.26
- `.github/workflows/go-postsubmit.yml` — GO_VERSION updated to 1.26
- `.github/workflows/go-release.yml` — GO_VERSION updated to 1.26

Relates to: https://github.com/open-cluster-management-io/ocm/issues/1555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain to **1.26** across CI workflows (presubmit, postsubmit, and release), the module toolchain directive, and Docker build stages (standard and e2e). Builds, tests, and release packaging now run with Go **1.26** instead of **1.25**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->