### PR TITLE
Fix TokenReview expired credential fallback

### DIFF
--- a/pkg/serviceproxy/token_authenticator.go
+++ b/pkg/serviceproxy/token_authenticator.go
@@ -22,9 +22,15 @@ var ErrTokenNotAuthenticated = errors.New("token not authenticated")
 // authRejectionPatterns contains substrings of TokenReview Status.Error that
 // indicate the token was rejected by the authenticator. Observed from:
 //   - Kubernetes v1.35: "invalid bearer token"
+//   - Kubernetes service account token authenticator: "service account token has expired"
+//   - Kubernetes OIDC token authenticator: "oidc: token is expired"
 //   - OpenShift 4.x:    "[invalid bearer token, token lookup failed]"
+//   - OpenShift OAuth API server: "token is expired"
 var authRejectionPatterns = []string{
 	"invalid bearer token",
+	"service account token has expired",
+	"oidc: token is expired",
+	"token is expired",
 }
 
 // isAuthRejection reports whether a TokenReview Status.Error indicates an

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -295,6 +295,18 @@ func TestTokenReviewAuthenticator_StatusError_KnownRejection(t *testing.T) {
 			name:        "OpenShift: invalid bearer token with token lookup failed",
 			statusError: "[invalid bearer token, token lookup failed]",
 		},
+		{
+			name:        "Kubernetes: expired service account token",
+			statusError: "service account token has expired",
+		},
+		{
+			name:        "Kubernetes: expired OIDC token",
+			statusError: "oidc: token is expired (Token Expiry: 2026-06-16 05:00:00 +0000 UTC)",
+		},
+		{
+			name:        "OpenShift: expired OAuth token",
+			statusError: "token is expired",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Handle expired TokenReview credential errors as authentication rejections so service-proxy can fall back to hub authentication.

## Reference
Kubernetes docs show `Credentials are expired` as a TokenReview authentication failure example:
https://github.com/kubernetes/website/blob/main/content/en/docs/reference/access-authn-authz/authentication.md?plain=1#L1137-L1145

## Related issue(s)
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication error handling to properly recognize and classify expired credentials as authentication rejections.

* **Tests**
  * Added test coverage for expired credential error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->