### PR TITLE
Collapse addon-agent lease updater construction

### DIFF
--- a/cmd/addon-agent/main.go
+++ b/cmd/addon-agent/main.go
@@ -97,22 +97,17 @@ func main() {
 		panic(fmt.Sprintf("Pod namespace is empty, please set the ENV for %s", envKeyPodNamespace))
 	}
 
-	var leaseUpdater lease.LeaseUpdater
+	var healthCheckFuncs []func() bool
 	if enableProxyAgentHealthCheck {
 		klog.Infof("Proxy-agent health check enabled, lease will only update when proxy-agent is connected")
-		leaseUpdater = lease.NewLeaseUpdater(
-			spokeClient,
-			common.AddonName,
-			addonAgentNamespace,
-			checkProxyAgentReadiness(),
-		).WithHubLeaseConfig(cfg, clusterName)
-	} else {
-		leaseUpdater = lease.NewLeaseUpdater(
-			spokeClient,
-			common.AddonName,
-			addonAgentNamespace,
-		).WithHubLeaseConfig(cfg, clusterName)
+		healthCheckFuncs = []func() bool{checkProxyAgentReadiness()}
 	}
+	leaseUpdater := lease.NewLeaseUpdater(
+		spokeClient,
+		common.AddonName,
+		addonAgentNamespace,
+		healthCheckFuncs...,
+	).WithHubLeaseConfig(cfg, clusterName)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Build optional proxy-agent readiness checks first, then pass them into a single `lease.NewLeaseUpdater` call to remove duplicated lease updater construction while preserving behavior.

## Related issue(s)
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization logic for the lease updater component, consolidating conditional branching into a more streamlined approach while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->