### PR TITLE
:bug: Stabilize e2e readiness checks

### DIFF
--- a/test/e2e/connect_test.go
+++ b/test/e2e/connect_test.go
@@ -221,8 +221,8 @@ var _ = Describe("Requests through Cluster-Proxy", Label("serviceproxy", "connec
 				Stderr: &stderr,
 				Tty:    false,
 			})
-			Expect(err).To(BeNil())
-			Expect(strings.Contains(stdout.String(), "hello")).To(Equal(true))
+			Expect(err).To(BeNil(), stderr.String())
+			Expect(strings.Contains(stdout.String(), "hello")).To(BeTrue(), "stderr: %s", stderr.String())
 		})
 	})
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
@@ -79,11 +80,31 @@ var _ = Describe("Install Test", Label("install", "deployment"),
 			tolerations := []corev1.Toleration{{Key: "node-role.kubernetes.io/infra", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}}
 
 			By("Cleanup existing AddOnDeploymentConfig if any")
-			_ = hubRuntimeClient.Delete(context.TODO(), &addonapiv1alpha1.AddOnDeploymentConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      deployConfigName,
-					Namespace: managedClusterName,
-				},
+			Expect(deleteAddOnDeploymentConfig(deployConfigName)).To(Succeed())
+
+			waitProxyAgentDeploymentRolledOut()
+			originalAddon, err := getManagedClusterAddon()
+			Expect(err).ToNot(HaveOccurred())
+			originalConfigs := originalAddon.Spec.Configs
+
+			originalDeployment, err := getProxyAgentDeployment()
+			Expect(err).ToNot(HaveOccurred())
+			originalNodeSelector := originalDeployment.Spec.Template.Spec.NodeSelector
+			originalTolerations := originalDeployment.Spec.Template.Spec.Tolerations
+			originalReplicas := ptr.Deref(originalDeployment.Spec.Replicas, 1)
+
+			DeferCleanup(func() {
+				By("Restore cluster-proxy addon config after test")
+				Eventually(func() error {
+					return setManagedClusterAddonConfigs(originalConfigs)
+				}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+
+				By("Cleanup AddOnDeploymentConfig after test")
+				Expect(deleteAddOnDeploymentConfig(deployConfigName)).To(Succeed())
+
+				By("Wait for cluster-proxy deployment to return to the previous placement")
+				waitProxyAgentDeploymentConfigured(originalNodeSelector, originalTolerations, originalReplicas)
+				waitManagedClusterAddonAvailable()
 			})
 
 			By("Prepare a AddOnDeployMentConfig for cluster-proxy")
@@ -103,105 +124,21 @@ var _ = Describe("Install Test", Label("install", "deployment"),
 				})
 			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
 
-			DeferCleanup(func() {
-				By("Cleanup AddOnDeploymentConfig after test")
-				_ = hubRuntimeClient.Delete(context.TODO(), &addonapiv1alpha1.AddOnDeploymentConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deployConfigName,
-						Namespace: managedClusterName,
-					},
-				})
-			})
-
 			By("Add the config to cluster-proxy")
 			Eventually(func() error {
-				addon := &addonapiv1alpha1.ManagedClusterAddOn{}
-				if err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: managedClusterName,
-					Name:      "cluster-proxy",
-				}, addon); err != nil {
-					return err
-				}
-
-				addon.Spec.Configs = []addonapiv1alpha1.AddOnConfig{
-					{
-						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-							Group:    "addon.open-cluster-management.io",
-							Resource: "addondeploymentconfigs",
-						},
-						ConfigReferent: addonapiv1alpha1.ConfigReferent{
-							Namespace: managedClusterName,
-							Name:      deployConfigName,
-						},
-					},
-				}
-
-				return hubRuntimeClient.Update(context.TODO(), addon)
+				return setManagedClusterAddonConfigs([]addonapiv1alpha1.AddOnConfig{
+					addOnDeploymentConfigReference(deployConfigName),
+				})
 			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
 
 			By("Ensure the config is referenced")
-			Eventually(func() error {
-				addon := &addonapiv1alpha1.ManagedClusterAddOn{}
-				if err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: managedClusterName,
-					Name:      "cluster-proxy",
-				}, addon); err != nil {
-					return err
-				}
-
-				if len(addon.Status.ConfigReferences) == 0 {
-					return fmt.Errorf("no config references in addon status")
-				}
-				for _, cr := range addon.Status.ConfigReferences {
-					if cr.Name == deployConfigName {
-						return nil
-					}
-				}
-				return fmt.Errorf("unexpected config references %v", addon.Status.ConfigReferences)
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			waitManagedClusterAddonConfigReferenced(deployConfigName)
 
 			By("Ensure the cluster-proxy is configured")
-			Eventually(func() error {
-				deploy := &appsv1.Deployment{}
-				if err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: config.DefaultAddonInstallNamespace,
-					Name:      "cluster-proxy-proxy-agent",
-				}, deploy); err != nil {
-					return err
-				}
-
-				if deploy.Status.AvailableReplicas != *deploy.Spec.Replicas {
-					return fmt.Errorf("unexpected available replicas %v", deploy.Status)
-				}
-
-				if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.NodeSelector, nodeSelector) {
-					return fmt.Errorf("unexpected nodeSeletcor %v", deploy.Spec.Template.Spec.NodeSelector)
-				}
-
-				if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.Tolerations, tolerations) {
-					return fmt.Errorf("unexpected tolerations %v", deploy.Spec.Template.Spec.Tolerations)
-				}
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			waitProxyAgentDeploymentConfigured(nodeSelector, tolerations, originalReplicas)
 
 			By("Ensure the cluster-proxy is available")
-			Eventually(func() error {
-				addon := &addonapiv1alpha1.ManagedClusterAddOn{}
-				if err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: managedClusterName,
-					Name:      "cluster-proxy",
-				}, addon); err != nil {
-					return err
-				}
-
-				if !meta.IsStatusConditionTrue(
-					addon.Status.Conditions,
-					addonapiv1alpha1.ManagedClusterAddOnConditionAvailable) {
-					return fmt.Errorf("addon is unavailable")
-				}
-
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			waitManagedClusterAddonAvailable()
 		})
 
 		It("ClusterProxy configuration - check configuration generation", Label("configuration", "generation"), func() {
@@ -211,40 +148,32 @@ var _ = Describe("Install Test", Label("install", "deployment"),
 			}, proxyConfiguration)
 			Expect(err).ToNot(HaveOccurred())
 
+			expectedGenerationAnnotation := strconv.Itoa(int(proxyConfiguration.Generation))
 			Eventually(func() error {
-				expectedGeneration := proxyConfiguration.Generation
 				proxyServerDeploy := &appsv1.Deployment{}
-				err = hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
+				err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
 					Namespace: proxyConfiguration.Spec.ProxyServer.Namespace,
 					Name:      "cluster-proxy",
 				}, proxyServerDeploy)
 				if err != nil {
 					return err
 				}
-				if proxyServerDeploy.Annotations[common.AnnotationKeyConfigurationGeneration] != strconv.Itoa(int(expectedGeneration)) {
+				if proxyServerDeploy.Annotations[common.AnnotationKeyConfigurationGeneration] != expectedGenerationAnnotation {
 					return fmt.Errorf("proxy server deployment is not updated")
-				}
-
-				proxyAgentDeploy := &appsv1.Deployment{}
-				err = hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: config.DefaultAddonInstallNamespace,
-					Name:      proxyConfiguration.Name + "-" + common.ComponentNameProxyAgent,
-				}, proxyAgentDeploy)
-				if err != nil {
-					return err
-				}
-				if proxyAgentDeploy.Annotations[common.AnnotationKeyConfigurationGeneration] != strconv.Itoa(int(expectedGeneration)) {
-					return fmt.Errorf("proxy agent deployment is not updated")
 				}
 
 				return nil
 			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
 
-			waitAgentReady(proxyConfiguration, hubKubeClient)
+			waitProxyAgentReady(proxyConfiguration, hubKubeClient)
 		})
 	})
 
-func waitAgentReady(proxyConfiguration *proxyv1alpha1.ManagedProxyConfiguration, client kubernetes.Interface) {
+func waitProxyAgentReady(proxyConfiguration *proxyv1alpha1.ManagedProxyConfiguration, client kubernetes.Interface) {
+	waitProxyAgentDeploymentGenerationRolledOut(proxyConfiguration.Generation, proxyConfiguration.Spec.ProxyAgent.Replicas)
+
+	expectedGenerationAnnotation := strconv.Itoa(int(proxyConfiguration.Generation))
+	expectedReplicas := int(proxyConfiguration.Spec.ProxyAgent.Replicas)
 	Eventually(
 		func() int {
 			podList, err := client.CoreV1().
@@ -255,6 +184,9 @@ func waitAgentReady(proxyConfiguration *proxyv1alpha1.ManagedProxyConfiguration,
 			Expect(err).NotTo(HaveOccurred())
 			matchedGeneration := 0
 			for _, pod := range podList.Items {
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
 				allReady := true
 				for _, st := range pod.Status.ContainerStatuses {
 					if !st.Ready {
@@ -262,12 +194,181 @@ func waitAgentReady(proxyConfiguration *proxyv1alpha1.ManagedProxyConfiguration,
 					}
 				}
 				if allReady &&
-					pod.Annotations[common.AnnotationKeyConfigurationGeneration] == strconv.Itoa(int(proxyConfiguration.Generation)) {
+					pod.Annotations[common.AnnotationKeyConfigurationGeneration] == expectedGenerationAnnotation {
 					matchedGeneration++
 				}
 			}
 			return matchedGeneration
 		}).
 		WithTimeout(time.Second * 30).
-		Should(Equal(int(proxyConfiguration.Spec.ProxyAgent.Replicas)))
+		Should(Equal(expectedReplicas))
+}
+
+func waitManagedClusterAddonAvailable() {
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon()
+		if err != nil {
+			return err
+		}
+
+		if !meta.IsStatusConditionTrue(
+			addon.Status.Conditions,
+			addonapiv1alpha1.ManagedClusterAddOnConditionAvailable) {
+			return fmt.Errorf("addon is unavailable")
+		}
+
+		return nil
+	}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+}
+
+func waitManagedClusterAddonConfigReferenced(name string) {
+	expected := addOnDeploymentConfigReference(name)
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon()
+		if err != nil {
+			return err
+		}
+
+		for _, cr := range addon.Status.ConfigReferences {
+			if cr.ConfigGroupResource == expected.ConfigGroupResource &&
+				cr.ConfigReferent == expected.ConfigReferent {
+				return nil
+			}
+		}
+		return fmt.Errorf("config reference %s/%s not found in addon status: %v",
+			expected.Namespace, expected.Name, addon.Status.ConfigReferences)
+	}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+}
+
+func setManagedClusterAddonConfigs(configs []addonapiv1alpha1.AddOnConfig) error {
+	addon, err := getManagedClusterAddon()
+	if err != nil {
+		return err
+	}
+
+	addon.Spec.Configs = configs
+	return hubRuntimeClient.Update(context.TODO(), addon)
+}
+
+func getManagedClusterAddon() (*addonapiv1alpha1.ManagedClusterAddOn, error) {
+	addon := &addonapiv1alpha1.ManagedClusterAddOn{}
+	err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: managedClusterName,
+		Name:      "cluster-proxy",
+	}, addon)
+	return addon, err
+}
+
+func addOnDeploymentConfigReference(name string) addonapiv1alpha1.AddOnConfig {
+	return addonapiv1alpha1.AddOnConfig{
+		ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+			Group:    "addon.open-cluster-management.io",
+			Resource: "addondeploymentconfigs",
+		},
+		ConfigReferent: addonapiv1alpha1.ConfigReferent{
+			Namespace: managedClusterName,
+			Name:      name,
+		},
+	}
+}
+
+func deleteAddOnDeploymentConfig(name string) error {
+	err := hubRuntimeClient.Delete(context.TODO(), &addonapiv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: managedClusterName,
+		},
+	})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func waitProxyAgentDeploymentConfigured(
+	expectedNodeSelector map[string]string,
+	expectedTolerations []corev1.Toleration,
+	expectedReplicas int32,
+) {
+	Eventually(func() error {
+		deploy, err := getProxyAgentDeployment()
+		if err != nil {
+			return err
+		}
+
+		if err := proxyAgentRolledOut(deploy, expectedReplicas); err != nil {
+			return err
+		}
+
+		if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.NodeSelector, expectedNodeSelector) {
+			return fmt.Errorf("unexpected nodeSelector %v", deploy.Spec.Template.Spec.NodeSelector)
+		}
+
+		if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.Tolerations, expectedTolerations) {
+			return fmt.Errorf("unexpected tolerations %v", deploy.Spec.Template.Spec.Tolerations)
+		}
+
+		return nil
+	}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+}
+
+func waitProxyAgentDeploymentGenerationRolledOut(expectedGeneration int64, expectedReplicas int32) {
+	expectedGenerationAnnotation := strconv.Itoa(int(expectedGeneration))
+	Eventually(func() error {
+		deploy, err := getProxyAgentDeployment()
+		if err != nil {
+			return err
+		}
+
+		if deploy.Annotations[common.AnnotationKeyConfigurationGeneration] != expectedGenerationAnnotation {
+			return fmt.Errorf("proxy agent deployment generation annotation is not updated")
+		}
+		if deploy.Spec.Template.Annotations[common.AnnotationKeyConfigurationGeneration] != expectedGenerationAnnotation {
+			return fmt.Errorf("proxy agent pod template generation annotation is not updated")
+		}
+
+		return proxyAgentRolledOut(deploy, expectedReplicas)
+	}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+}
+
+func waitProxyAgentDeploymentRolledOut() {
+	Eventually(func() error {
+		deploy, err := getProxyAgentDeployment()
+		if err != nil {
+			return err
+		}
+
+		return proxyAgentRolledOut(deploy, ptr.Deref(deploy.Spec.Replicas, 1))
+	}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+}
+
+// proxyAgentRolledOut returns nil only once the proxy agent deployment has fully
+// rolled out the latest generation to expectedReplicas pods with none unavailable.
+func proxyAgentRolledOut(deploy *appsv1.Deployment, expectedReplicas int32) error {
+	if deploy.Status.ObservedGeneration < deploy.Generation {
+		return fmt.Errorf("proxy agent deployment generation %d has not been observed: %v", deploy.Generation, deploy.Status)
+	}
+
+	if specReplicas := ptr.Deref(deploy.Spec.Replicas, 1); specReplicas != expectedReplicas {
+		return fmt.Errorf("unexpected proxy agent spec replicas %d", specReplicas)
+	}
+
+	if deploy.Status.Replicas != expectedReplicas ||
+		deploy.Status.UpdatedReplicas != expectedReplicas ||
+		deploy.Status.ReadyReplicas != expectedReplicas ||
+		deploy.Status.AvailableReplicas != expectedReplicas ||
+		deploy.Status.UnavailableReplicas != 0 {
+		return fmt.Errorf("proxy agent deployment rollout is incomplete: %v", deploy.Status)
+	}
+
+	return nil
+}
+
+func getProxyAgentDeployment() (*appsv1.Deployment, error) {
+	deploy := &appsv1.Deployment{}
+	err := hubRuntimeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: config.DefaultAddonInstallNamespace,
+		Name:      "cluster-proxy-proxy-agent",
+	}, deploy)
+	return deploy, err
 }


### PR DESCRIPTION
## Summary

- Wait for the proxy-agent Deployment to finish rolling out before checking e2e readiness.
- Check only pods from the latest addon configuration and skip pods that are already being deleted.
- Save the existing cluster-proxy addon config before the deployment config e2e test, then restore it afterward so later checks start from the original state.
- Include `stderr` from failed `exec` calls in connection test errors so failures are easier to debug.
