### PR TITLE
Harden Helm chart pod security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: get release version
@@ -45,7 +45,7 @@ jobs:
       contents: write
     steps:
       - name: submit charts to OCM chart repo
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
+      uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # v1.3.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # v1.1.0
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -21,11 +21,11 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -47,7 +47,7 @@ jobs:
     needs: [images]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: create

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: build
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: verify
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: setup helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.20.1
       - name: test helm charts
@@ -60,15 +60,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: unit
         run: make test
       - name: report coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./cover.out
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: integration
@@ -95,15 +95,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Install clusteradm
         run: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: e2e
       - name: Build image

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -41,6 +41,20 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: verify
         run: make verify
+
+  helm:
+    name: helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: setup helm
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.20.1
+      - name: test helm charts
+        run: make test-helm
+
   unit:
     name: unit
     runs-on: ubuntu-latest

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: get release version
@@ -43,11 +43,11 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -69,7 +69,7 @@ jobs:
     needs: [env, images]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: create
@@ -93,11 +93,13 @@ jobs:
     needs: [env, image-manifest]
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: setup helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.1
       - name: chart package
         run: |
           mkdir -p release
@@ -108,7 +110,7 @@ jobs:
         run: |
           echo "# Cluster Proxy ${{ needs.env.outputs.RELEASE_VERSION }}" > /home/runner/work/changelog.txt
       - name: publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMAGE_NAME = cluster-proxy
 IMAGE_TAG ?= latest
 E2E_TEST_CLUSTER_NAME ?= e2e
 CONTAINER_ENGINE ?= docker
+HELM ?= helm
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions={v1},allowDangerousTypes=true,generateEmbeddedObjectMeta=true"
 
@@ -74,6 +75,23 @@ envtest-setup:
 
 test: manifests generate fmt vet envtest-setup ## Run tests.
 	go test ./pkg/... -coverprofile cover.out
+
+.PHONY: test-helm
+test-helm: ## Lint and render Helm charts.
+	$(HELM) lint charts/cluster-proxy
+	$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon >/dev/null
+	$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon \
+		--set enableServiceProxy=true >/dev/null
+	$(HELM) lint pkg/proxyagent/agent/manifests/charts/addon-agent
+	$(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
+		--namespace open-cluster-management-agent-addon >/dev/null
+	$(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
+		--namespace open-cluster-management-agent-addon \
+		--set enableServiceProxy=true \
+		--set serviceProxySecretCert=dGVzdA== \
+		--set serviceProxySecretKey=dGVzdA== >/dev/null
 
 ##@ Build
 

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         component: cluster-proxy-manager
     spec:
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         component: cluster-proxy-addon-user
     spec:
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: controllers
           image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -727,8 +727,19 @@ func TestNewAgentAddon(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
+			assertRuntimeDefaultSeccompProfile(t, getAgentDeployment(manifests))
 			c.verifyManifests(t, manifests)
 		})
+	}
+}
+
+func assertRuntimeDefaultSeccompProfile(t *testing.T, deploy *appsv1.Deployment) {
+	t.Helper()
+
+	if assert.NotNil(t, deploy) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
+		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
 	}
 }
 

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - {{ .Values.serviceProxyHost }}
       {{- end }}
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.agentDeploymentName }}
-  annotations:
   {{- with .Values.agentDeploymentAnnotations }}
-  {{ toYaml . | indent 2 }}
+  annotations:
+{{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -17,17 +17,19 @@ spec:
     metadata:
       annotations:
       {{- with .Values.agentDeploymentAnnotations }}
-      {{ toYaml . | indent 2 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         open-cluster-management.io/addon: cluster-proxy
         proxy.open-cluster-management.io/component-name: proxy-agent
     spec:
+      {{- if .Values.serviceProxyHost }}
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:
         - {{ .Values.serviceProxyHost }}
+      {{- end }}
       serviceAccount: cluster-proxy
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
@@ -217,7 +219,9 @@ spec:
           secret:
             secretName: cluster-proxy-service-proxy-server-certificates
         {{- end }}
+      {{- with .Values.proxyAgentImagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.proxyAgentImagePullSecrets }}
+      {{- range . }}
       - name: {{ . }}
+      {{- end }}
       {{- end }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -9,6 +9,7 @@ registry: quay.io/open-cluster-management
 
 # Image of the cluster-gateway instances
 image: cluster-proxy
+tag: latest
 
 proxyAgentImage: quay.io/open-cluster-management/cluster-proxy:latest
 proxyAgentImagePullSecrets: []

--- a/pkg/proxyserver/controllers/manifests.go
+++ b/pkg/proxyserver/controllers/manifests.go
@@ -118,6 +118,11 @@ func newProxyServerDeployment(config *proxyv1alpha1.ManagedProxyConfiguration, i
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: common.AddonName,
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            common.ComponentNameProxyServer,

--- a/pkg/proxyserver/controllers/manifests_test.go
+++ b/pkg/proxyserver/controllers/manifests_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
@@ -77,6 +78,20 @@ func TestProxyServerArgs_WithAdditionalArgsAndCipherSuites(t *testing.T) {
 		"--cipher-suites="+sdktls.CipherSuitesToString(tlsConfig.CipherSuites),
 	)
 	assert.Equal(t, expected, args)
+}
+
+func TestNewProxyServerDeployment_SetsRuntimeDefaultSeccompProfile(t *testing.T) {
+	config := newTestConfig(3)
+	config.Name = "cluster-proxy"
+	config.Spec.ProxyServer.Namespace = "test"
+	config.Spec.ProxyServer.Image = "quay.io/open-cluster-management/cluster-proxy:test"
+
+	deploy := newProxyServerDeployment(config, "IfNotPresent", nil)
+
+	if assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
+		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
+	}
 }
 
 func TestTLSConfigHash_Nil(t *testing.T) {

--- a/test/e2e/env/hello-world-https.yaml
+++ b/test/e2e/env/hello-world-https.yaml
@@ -38,6 +38,9 @@ metadata:
   labels:
     run: hello-world-https
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: hello-world-https
     image: alpine/openssl:latest

--- a/test/e2e/env/hello-world.yaml
+++ b/test/e2e/env/hello-world.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     run: hello-world
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: hello-world
     image: quay.io/prometheus/busybox

--- a/test/e2e/env/job.yaml
+++ b/test/e2e/env/job.yaml
@@ -41,6 +41,9 @@ spec:
         app: cluster-proxy-e2e
     spec:
       serviceAccountName: cluster-proxy-e2e
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Never
       containers:
         - name: e2e


### PR DESCRIPTION
## Summary
- fix the embedded addon-agent chart so default Helm render no longer emits invalid YAML
- set pod-level `seccompProfile.type: RuntimeDefault` on cluster-proxy workloads and e2e pods
- add a Helm chart CI target and presubmit job to lint/render both charts
- update GitHub Actions references to latest releases and pin them by commit SHA
- add Dependabot version updates for SHA-pinned GitHub Actions

## Details
The addon-agent chart defaulted to an empty image tag for some containers, which rendered `image: ...:` and caused Helm parsing to fail. The chart now uses `latest` as the standalone fallback while runtime values from the top-level chart still provide release-tagged images.

The top-level chart already defaults image tags to `v<Chart.Version>`, and release workflows verify that the chart version matches the release tag without the `v` prefix. That keeps normal releases on `vX.Y.Z` image tags while leaving addon-agent standalone rendering usable.

The Helm presubmit pins setup-helm to a current action SHA and Helm v3.20.1 so CI does not accidentally install an old Helm prerelease. Other workflow actions are also SHA-pinned with version comments for traceability.

Dependabot is configured for weekly grouped GitHub Actions updates from `.github/workflows`, so future action update PRs can move the pinned SHAs while preserving version comments.

## CodeRabbit follow-up
Addressed CodeRabbit's presubmit workflow hardening feedback in a follow-up commit. The presubmit workflow runs on `pull_request` and executes repository Make targets, so it should use the minimum GitHub token permissions needed, avoid persisting checkout credentials in git config, and avoid `setup-go`'s default cache writes for PR-executed jobs.

- Added top-level `permissions: contents: read` and `persist-credentials: false` on all `actions/checkout` steps: https://github.com/open-cluster-management-io/cluster-proxy/pull/305#discussion_r3425728676
- Added `cache: false` on all `actions/setup-go` steps in `go-presubmit.yml`: https://github.com/open-cluster-management-io/cluster-proxy/pull/305#discussion_r3425728686

## Validation
- `go test ./pkg/proxyagent/agent ./pkg/proxyserver/controllers`
- `go test ./pkg/...`
- `make test-helm`
- workflow YAML parse check and SHA-pin check for every `uses:` entry
- `git diff --check`
- `yq '.' .github/workflows/go-presubmit.yml`
- custom workflow hardening check for permissions, checkout credential persistence, and setup-go cache settings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Applied pod-level RuntimeDefault seccomp profile configuration to cluster proxy deployments (manager, user) and test pod manifests.

* **CI/CD & Automation**
  * Configured automated dependency updates for GitHub Actions repositories using Dependabot with weekly scheduling.
  * Pinned third-party action versions to specific commit hashes to ensure build consistency and reproducibility.
  * Added Helm chart linting and template validation as new build pipeline steps.

* **Tests**
  * Implemented validation tests to verify seccomp profile configuration in generated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
