### PR TITLE
:seedling: Add Helm chart presubmit checks

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -42,18 +42,22 @@ jobs:
       - name: verify
         run: make verify
 
-  helm-dependencies:
-    name: helm dependencies
+  helm:
+    name: helm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: setup helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.20.1
-      - name: verify helm dependencies
-        run: make verify-helm-dependencies
+      - name: test helm charts
+        run: make test-helm
 
   unit:
     name: unit

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,23 @@ verify-helm-dependencies: ## Verify Helm chart dependencies are committed and cu
 test: manifests generate fmt vet envtest-setup ## Run tests.
 	go test ./pkg/... -coverprofile cover.out
 
+.PHONY: test-helm
+test-helm: verify-helm-dependencies ## Lint and render Helm charts.
+	$(HELM) lint charts/cluster-proxy
+	$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon >/dev/null
+	$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon \
+		--set enableServiceProxy=true >/dev/null
+	$(HELM) lint pkg/proxyagent/agent/manifests/charts/addon-agent
+	$(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
+		--namespace open-cluster-management-agent-addon >/dev/null
+	$(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
+		--namespace open-cluster-management-agent-addon \
+		--set enableServiceProxy=true \
+		--set serviceProxySecretCert=dGVzdA== \
+		--set serviceProxySecretKey=dGVzdA== >/dev/null
+
 ##@ Build
 
 build: generate fmt vet


### PR DESCRIPTION
## Summary

- Add a `make test-helm` target that lints and renders the cluster-proxy Helm charts.
- Exercise the default deployment path and service-proxy rendering for both the top-level `cluster-proxy` chart and the embedded `addon-agent` chart.
- Add a dedicated least-privilege `helm` presubmit job to run the chart checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened Helm chart validation in the CI/CD pipeline
  * Updated to Helm v3.20.1 with pinned version dependencies for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->