### PR TITLE
:seedling: Harden cluster-proxy pod security contexts

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -54,7 +54,7 @@ jobs:
       - name: unit
         run: make test
       - name: report coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./cover.out

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       serviceAccount: cluster-proxy
       securityContext:
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         component: cluster-proxy-manager
     spec:
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         component: cluster-proxy-addon-user
     spec:
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: controllers
           image: {{ .Values.registry }}/{{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       serviceAccount: cluster-proxy
       securityContext:
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -727,8 +727,19 @@ func TestNewAgentAddon(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
+			assertRuntimeDefaultSeccompProfile(t, getAgentDeployment(manifests))
 			c.verifyManifests(t, manifests)
 		})
+	}
+}
+
+func assertRuntimeDefaultSeccompProfile(t *testing.T, deploy *appsv1.Deployment) {
+	t.Helper()
+
+	if assert.NotNil(t, deploy) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
+		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
 	}
 }
 

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/utils/ptr"
 
 	openshiftcrypto "github.com/openshift/library-go/pkg/crypto"
 	"github.com/stretchr/testify/assert"
@@ -727,20 +728,25 @@ func TestNewAgentAddon(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			assertRuntimeDefaultSeccompProfile(t, getAgentDeployment(manifests))
+			assertPodSecurityContext(t, getAgentDeployment(manifests))
 			c.verifyManifests(t, manifests)
 		})
 	}
 }
 
-func assertRuntimeDefaultSeccompProfile(t *testing.T, deploy *appsv1.Deployment) {
+func assertPodSecurityContext(t *testing.T, deploy *appsv1.Deployment) {
 	t.Helper()
 
-	if assert.NotNil(t, deploy) &&
-		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
-		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
-		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
+	if !assert.NotNil(t, deploy) {
+		return
 	}
+	expected := &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	assert.Equal(t, expected, deploy.Spec.Template.Spec.SecurityContext)
 }
 
 type fakeSelfSigner struct {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - {{ .Values.serviceProxyHost }}
       {{- end }}
       serviceAccount: cluster-proxy
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.agentDeploymentName }}
-  annotations:
   {{- with .Values.agentDeploymentAnnotations }}
-  {{ toYaml . | indent 2 }}
+  annotations:
+{{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -17,17 +17,19 @@ spec:
     metadata:
       annotations:
       {{- with .Values.agentDeploymentAnnotations }}
-      {{ toYaml . | indent 2 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         open-cluster-management.io/addon: cluster-proxy
         proxy.open-cluster-management.io/component-name: proxy-agent
     spec:
+      {{- if .Values.serviceProxyHost }}
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:
         - {{ .Values.serviceProxyHost }}
+      {{- end }}
       serviceAccount: cluster-proxy
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
@@ -217,7 +219,9 @@ spec:
           secret:
             secretName: cluster-proxy-service-proxy-server-certificates
         {{- end }}
+      {{- with .Values.proxyAgentImagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.proxyAgentImagePullSecrets }}
+      {{- range . }}
       - name: {{ . }}
+      {{- end }}
       {{- end }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       {{- end }}
       serviceAccount: cluster-proxy
       securityContext:
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       {{- if .Values.tolerations }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -9,6 +9,7 @@ registry: quay.io/open-cluster-management
 
 # Image of the cluster-gateway instances
 image: cluster-proxy
+tag: latest
 
 proxyAgentImage: quay.io/open-cluster-management/cluster-proxy:latest
 proxyAgentImagePullSecrets: []

--- a/pkg/proxyserver/controllers/manifests.go
+++ b/pkg/proxyserver/controllers/manifests.go
@@ -118,6 +118,11 @@ func newProxyServerDeployment(config *proxyv1alpha1.ManagedProxyConfiguration, i
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: common.AddonName,
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            common.ComponentNameProxyServer,

--- a/pkg/proxyserver/controllers/manifests.go
+++ b/pkg/proxyserver/controllers/manifests.go
@@ -119,6 +119,7 @@ func newProxyServerDeployment(config *proxyv1alpha1.ManagedProxyConfiguration, i
 				Spec: corev1.PodSpec{
 					ServiceAccountName: common.AddonName,
 					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},

--- a/pkg/proxyserver/controllers/manifests_test.go
+++ b/pkg/proxyserver/controllers/manifests_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
@@ -80,7 +81,7 @@ func TestProxyServerArgs_WithAdditionalArgsAndCipherSuites(t *testing.T) {
 	assert.Equal(t, expected, args)
 }
 
-func TestNewProxyServerDeployment_SetsRuntimeDefaultSeccompProfile(t *testing.T) {
+func TestNewProxyServerDeployment_SetsPodSecurityContext(t *testing.T) {
 	config := newTestConfig(3)
 	config.Name = "cluster-proxy"
 	config.Spec.ProxyServer.Namespace = "test"
@@ -88,10 +89,13 @@ func TestNewProxyServerDeployment_SetsRuntimeDefaultSeccompProfile(t *testing.T)
 
 	deploy := newProxyServerDeployment(config, "IfNotPresent", nil)
 
-	if assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
-		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
-		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
+	expected := &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
+	assert.Equal(t, expected, deploy.Spec.Template.Spec.SecurityContext)
 }
 
 func TestTLSConfigHash_Nil(t *testing.T) {

--- a/pkg/proxyserver/controllers/manifests_test.go
+++ b/pkg/proxyserver/controllers/manifests_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
@@ -77,6 +78,20 @@ func TestProxyServerArgs_WithAdditionalArgsAndCipherSuites(t *testing.T) {
 		"--cipher-suites="+sdktls.CipherSuitesToString(tlsConfig.CipherSuites),
 	)
 	assert.Equal(t, expected, args)
+}
+
+func TestNewProxyServerDeployment_SetsRuntimeDefaultSeccompProfile(t *testing.T) {
+	config := newTestConfig(3)
+	config.Name = "cluster-proxy"
+	config.Spec.ProxyServer.Namespace = "test"
+	config.Spec.ProxyServer.Image = "quay.io/open-cluster-management/cluster-proxy:test"
+
+	deploy := newProxyServerDeployment(config, "IfNotPresent", nil)
+
+	if assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext) &&
+		assert.NotNil(t, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile) {
+		assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, deploy.Spec.Template.Spec.SecurityContext.SeccompProfile.Type)
+	}
 }
 
 func TestTLSConfigHash_Nil(t *testing.T) {

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -27,6 +27,8 @@ COPY --from=builder /e2e /e2e
 # Make binary executable
 RUN chmod +x /e2e
 
+USER 65532:65532
+
 # Default entrypoint - can be overridden with additional args
 # Supports Ginkgo v2 flags like --label-filter
 ENTRYPOINT ["/e2e"]

--- a/test/e2e/env/hello-world-https.yaml
+++ b/test/e2e/env/hello-world-https.yaml
@@ -38,6 +38,9 @@ metadata:
   labels:
     run: hello-world-https
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: hello-world-https
     image: alpine/openssl:latest

--- a/test/e2e/env/hello-world-https.yaml
+++ b/test/e2e/env/hello-world-https.yaml
@@ -39,12 +39,27 @@ metadata:
     run: hello-world-https
 spec:
   securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
     seccompProfile:
       type: RuntimeDefault
   containers:
   - name: hello-world-https
     image: alpine/openssl:latest
     imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+    env:
+    - name: HOME
+      value: /tmp
     command:
     - /bin/sh
     - /scripts/server.sh
@@ -53,11 +68,24 @@ spec:
     volumeMounts:
     - name: script
       mountPath: /scripts
+      readOnly: true
+    - name: certs
+      mountPath: /certs
+    - name: www
+      mountPath: /var/www
+    - name: tmp
+      mountPath: /tmp
   volumes:
   - name: script
     configMap:
       name: hello-world-https-script
       defaultMode: 0755
+  - name: certs
+    emptyDir: {}
+  - name: www
+    emptyDir: {}
+  - name: tmp
+    emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/env/hello-world.yaml
+++ b/test/e2e/env/hello-world.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     run: hello-world
 spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: hello-world
     image: quay.io/prometheus/busybox

--- a/test/e2e/env/hello-world.yaml
+++ b/test/e2e/env/hello-world.yaml
@@ -8,18 +8,36 @@ metadata:
     run: hello-world
 spec:
   securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
     seccompProfile:
       type: RuntimeDefault
   containers:
   - name: hello-world
     image: quay.io/prometheus/busybox
     imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
     args:
     - sh
     - -c
     - echo 'Hello from hello-world' > /var/www/index.html && httpd -f -p 8000 -h /var/www/
+    volumeMounts:
+    - name: www
+      mountPath: /var/www
     ports:
     - containerPort: 8000
+  volumes:
+  - name: www
+    emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/env/job.yaml
+++ b/test/e2e/env/job.yaml
@@ -42,6 +42,10 @@ spec:
     spec:
       serviceAccountName: cluster-proxy-e2e
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Never
@@ -50,6 +54,14 @@ spec:
           # Use the e2e test image built from test/e2e/Dockerfile
           image: quay.io/open-cluster-management/cluster-proxy-e2e:latest
           imagePullPolicy: Never
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           args:
             - -ginkgo.v
             - -ginkgo.label-filter=$(LABEL_FILTER)
@@ -71,3 +83,9 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/test/e2e/env/job.yaml
+++ b/test/e2e/env/job.yaml
@@ -41,6 +41,9 @@ spec:
         app: cluster-proxy-e2e
     spec:
       serviceAccountName: cluster-proxy-e2e
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Never
       containers:
         - name: e2e


### PR DESCRIPTION
## Summary

- Add Pod-level `runAsNonRoot: true` to cluster-proxy manager, user, addon-agent, and generated proxy-server deployments.
- Keep existing container-level hardening for product containers: no privilege escalation, dropped capabilities, non-root, and read-only root filesystems.
- Harden E2E images and sample workloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security hardening across deployments by enforcing non-root execution and runtime security profiles.
  * Improved container isolation with read-only filesystem enforcement and capability restrictions in test environments.

* **Tests**
  * Added validation tests to verify security context configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->