### PR TITLE
:seedling: Fix Dependabot PR title prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,5 +31,5 @@ updates:
         patterns:
           - "github.com/onsi/*"
     commit-message:
-      prefix: "ci"
+      prefix: ":seedling: ci"
       include: "scope"


### PR DESCRIPTION
## Summary
- Update Dependabot commit-message prefix so generated PR titles start with an allowed PR verifier indicator.
- Preserve the existing `ci(deps)` signal by using `:seedling: ci` as the prefix.

## Why
Dependabot currently creates titles like `ci(deps): ...`, but `.github/workflows/pr-verify.yml` requires PR titles to start with one of the configured emoji indicators.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to modify the commit message prefix format for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->