### PR TITLE
:seedling: Use OCM addon v1beta1

### DIFF
--- a/charts/cluster-proxy/README.md
+++ b/charts/cluster-proxy/README.md
@@ -26,7 +26,7 @@ helm install cluster-proxy ./charts/cluster-proxy \
 | `image`                                 | Image name                         | `cluster-proxy`                                 |
 | `tag`                                   | Image tag                          | Chart version                                   |
 | `replicas`                              | Number of replicas                 | `1`                                             |
-| `spokeAddonNamespace`                   | Namespace for spoke addon          | `open-cluster-management-cluster-proxy`         |
+| `spokeAddonNamespace`                   | Default agent install namespace    | `open-cluster-management-cluster-proxy`         |
 | `proxyServerImage`                      | Proxy server image                 | `quay.io/open-cluster-management/cluster-proxy` |
 | `proxyAgentImage`                       | Proxy agent image                  | `quay.io/open-cluster-management/cluster-proxy` |
 | `proxyServer.entrypointLoadBalancer`    | Enable LoadBalancer for entrypoint | `false`                                         |

--- a/charts/cluster-proxy/templates/clustermanagementaddon.yaml
+++ b/charts/cluster-proxy/templates/clustermanagementaddon.yaml
@@ -1,4 +1,4 @@
-apiVersion: addon.open-cluster-management.io/v1alpha1
+apiVersion: addon.open-cluster-management.io/v1beta1
 kind: ClusterManagementAddOn
 metadata:
   name: cluster-proxy
@@ -8,13 +8,10 @@ spec:
   addOnMeta:
     displayName: cluster-proxy
     description: cluster-proxy
-  supportedConfigs:
+  defaultConfigs:
   - group: proxy.open-cluster-management.io
     resource: managedproxyconfigurations
-    defaultConfig:
-      name: cluster-proxy
-  - group: addon.open-cluster-management.io
-    resource: addondeploymentconfigs
+    name: cluster-proxy
   installStrategy:
     type: Placements
     placements:

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - --enable-kube-api-proxy={{ .Values.enableKubeApiProxy }}
             - --enable-service-proxy={{ .Values.enableServiceProxy }}
             - --image-pull-policy={{ .Values.proxyServer.imagePullPolicy }}
+            - --agent-install-namespace={{ .Values.spokeAddonNamespace }}
             {{- if .Values.featureGates }}
             - --feature-gates=ClusterProfile={{ .Values.featureGates.clusterProfile | default false}}
             {{- end}}

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - --server-key=/user-tls/tls.key
             - --server-cert=/user-tls/tls.crt
             - --service-proxy-ca-cert=/proxy-ca/ca.crt
-            - --agent-install-namespace=open-cluster-management-agent-addon
+            - --agent-install-namespace={{ .Values.spokeAddonNamespace }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/hack/samples/clustermanagementaddon.yaml
+++ b/hack/samples/clustermanagementaddon.yaml
@@ -1,4 +1,4 @@
-apiVersion: addon.open-cluster-management.io/v1alpha1
+apiVersion: addon.open-cluster-management.io/v1beta1
 kind: ClusterManagementAddOn
 metadata:
   name: cluster-proxy
@@ -6,6 +6,7 @@ spec:
   addOnMeta:
     displayName: cluster-proxy
     description: cluster-proxy
-  addOnConfiguration:
-    crdName: managedproxyconfigurations.proxy.open-cluster-management.io
-    crName: cluster-proxy
+  defaultConfigs:
+  - group: proxy.open-cluster-management.io
+    resource: managedproxyconfigurations
+    name: cluster-proxy

--- a/hack/samples/managedclusteraddon.yaml
+++ b/hack/samples/managedclusteraddon.yaml
@@ -1,7 +1,19 @@
-apiVersion: addon.open-cluster-management.io/v1alpha1
+apiVersion: addon.open-cluster-management.io/v1beta1
+kind: AddOnDeploymentConfig
+metadata:
+  name: cluster-proxy
+  namespace: cluster-test2
+spec:
+  agentInstallNamespace: open-cluster-management-cluster-proxy
+---
+apiVersion: addon.open-cluster-management.io/v1beta1
 kind: ManagedClusterAddOn
 metadata:
   name: cluster-proxy
   namespace: cluster-test2
 spec:
-  installNamespace: "open-cluster-management-cluster-proxy"
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    namespace: cluster-test2
+    name: cluster-proxy

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -40,6 +40,7 @@ import (
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
+	"open-cluster-management.io/cluster-proxy/pkg/constant"
 	"open-cluster-management.io/cluster-proxy/pkg/proxyserver/operator/authentication/selfsigned"
 )
 
@@ -270,6 +271,9 @@ func TestNewAgentAddon(t *testing.T) {
 		"cluster-proxy-addon-agent-impersonator:open-cluster-management-cluster-proxy", // clusterrolebinding for impersonation
 	}
 
+	expectedManifestNamesWithServiceProxy := append([]string{}, expectedManifestNames...)
+	expectedManifestNamesWithServiceProxy = append(expectedManifestNamesWithServiceProxy, "cluster-proxy-service-proxy-server-certificates")
+
 	cases := []struct {
 		name                    string
 		cluster                 *clusterv1.ManagedCluster
@@ -278,6 +282,7 @@ func TestNewAgentAddon(t *testing.T) {
 		addOndDeploymentConfigs []runtime.Object
 		kubeObjs                []runtime.Object
 		enableKubeApiProxy      bool
+		enableServiceProxy      bool
 		expectedErrorMsg        string
 		verifyManifests         func(t *testing.T, manifests []runtime.Object)
 	}{
@@ -409,6 +414,32 @@ func TestNewAgentAddon(t *testing.T) {
 				agentDeploy := getAgentDeployment(manifests)
 				assert.NotNil(t, agentDeploy)
 				assert.Equal(t, getProxyServerHost(agentDeploy), "127.0.0.1")
+			},
+		},
+		{
+			name:    "port forward proxy server with service proxy",
+			cluster: newCluster(clusterName, true),
+			addon: func() *addonv1beta1.ManagedClusterAddOn {
+				addOn := newAddOn(addOnName, clusterName)
+				addOn.Status.ConfigReferences = []addonv1beta1.ConfigReference{newManagedProxyConfigReference(managedProxyConfigName)}
+				return addOn
+			}(),
+			managedProxyConfig:      newManagedProxyConfig(managedProxyConfigName, proxyv1alpha1.EntryPointTypePortForward),
+			addOndDeploymentConfigs: []runtime.Object{},
+			kubeObjs:                []runtime.Object{},
+			enableKubeApiProxy:      true,
+			enableServiceProxy:      true,
+			verifyManifests: func(t *testing.T, manifests []runtime.Object) {
+				assert.Len(t, manifests, len(expectedManifestNamesWithServiceProxy))
+				assert.ElementsMatch(t, expectedManifestNamesWithServiceProxy, manifestNames(manifests))
+				agentDeploy := getAgentDeployment(manifests)
+				assert.NotNil(t, agentDeploy)
+				serviceProxy := getDeploymentContainer(agentDeploy, "service-proxy")
+				if assert.NotNil(t, serviceProxy) &&
+					assert.NotNil(t, serviceProxy.ReadinessProbe) &&
+					assert.NotNil(t, serviceProxy.ReadinessProbe.TCPSocket) {
+					assert.Equal(t, int32(constant.ServiceProxyPort), serviceProxy.ReadinessProbe.TCPSocket.Port.IntVal)
+				}
 			},
 		},
 		{
@@ -718,7 +749,7 @@ func TestNewAgentAddon(t *testing.T) {
 				fakeRuntimeClient,
 				fakeKubeClient,
 				c.enableKubeApiProxy,
-				false, // enableServiceProxy
+				c.enableServiceProxy,
 				fakeAddonClient,
 			)
 			assert.NoError(t, err)
@@ -1071,6 +1102,18 @@ func getAgentDeployment(manifests []runtime.Object) *appsv1.Deployment {
 		}
 	}
 
+	return nil
+}
+
+func getDeploymentContainer(deploy *appsv1.Deployment, name string) *corev1.Container {
+	if deploy == nil {
+		return nil
+	}
+	for i := range deploy.Spec.Template.Spec.Containers {
+		if deploy.Spec.Template.Spec.Containers[i].Name == name {
+			return &deploy.Spec.Template.Spec.Containers[i]
+		}
+	}
 	return nil
 }
 

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -175,6 +175,10 @@ spec:
               port: 8000
             initialDelaySeconds: 2
             periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 7443
+            periodSeconds: 2
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary
- migrate OCM addon resources in the cluster-proxy chart from addon v1alpha1 to v1beta1
- add a v1beta1 AddOnDeploymentConfig for the default agent install namespace
- update samples to use AddOnDeploymentConfig and ManagedClusterAddOn spec.configs
- keep the cluster-proxy ManagedProxyConfiguration API at proxy v1alpha1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a readiness probe to the service-proxy container (TCP check on port 7443) when service proxy is enabled.
* **Documentation**
  * Updated the Helm chart value description for the agent installation namespace.
* **Chores**
  * Upgraded cluster proxy add-on manifests and samples to the v1beta1 API.
  * Updated Helm chart configuration wiring so the manager and user deployments install agents into the configured spoke add-on namespace.
* **Tests**
  * Extended agent tests to cover service-proxy behavior and expected generated manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->