### PR TITLE
:seedling: Ignore hack tool binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 /apiserver.local.config
 /bin
+/hack/tools/bin/
 /default.etcd
 /kubeconfig
 /config/crds/


### PR DESCRIPTION
Summary:
- Add `/hack/tools/bin/` to `.gitignore` so local hack tool binaries are not tracked.
