### PR TITLE
:seedling: Stabilize e2e readiness

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -139,5 +139,7 @@ jobs:
         run: make images
       - name: Setup environment
         run: make setup-env-for-e2e && make deploy-cluster-proxy-e2e
+      - name: Wait for cluster-proxy readiness
+        run: make wait-cluster-proxy-e2e
       - name: Run e2e tests
-        run: make test-e2e
+        run: make run-e2e-job

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMAGE_REGISTRY_NAME ?= quay.io/open-cluster-management
 IMAGE_NAME = cluster-proxy
 IMAGE_TAG ?= latest
 E2E_TEST_CLUSTER_NAME ?= e2e
+E2E_READINESS_TIMEOUT ?= 600
 CONTAINER_ENGINE ?= docker
 HELM ?= helm
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -209,6 +210,10 @@ deploy-cluster-proxy-e2e: delete-cluster-proxy-image-from-kind load-cluster-prox
 	@echo "Cluster-proxy deployed successfully!"
 .PHONY: deploy-cluster-proxy-e2e
 
+wait-cluster-proxy-e2e:
+	@./test/e2e/env/wait-for-cluster-proxy.sh $(E2E_READINESS_TIMEOUT)
+.PHONY: wait-cluster-proxy-e2e
+
 # Build e2e test container image
 build-e2e-image:
 	@echo "Building e2e test container image..."
@@ -233,9 +238,10 @@ delete-e2e-image-from-kind:
 	done
 .PHONY: delete-e2e-image-from-kind
 
-# Run e2e tests in cluster using container image (Kubernetes-native approach)
-# Use LABEL_FILTER to run specific tests, e.g.: make test-e2e LABEL_FILTER="install"
-test-e2e: delete-e2e-image-from-kind build-e2e-image load-e2e-image-kind
+# Run e2e test job in cluster using container image.
+# This target assumes cluster-proxy readiness was already checked by the caller.
+# Use LABEL_FILTER to run specific tests, e.g.: make run-e2e-job LABEL_FILTER="install"
+run-e2e-job: delete-e2e-image-from-kind build-e2e-image load-e2e-image-kind
 	@echo "Deleting existing e2e test job if present..."
 	@kubectl delete job cluster-proxy-e2e -n open-cluster-management-addon --ignore-not-found
 	@echo "Deploying e2e test job..."
@@ -246,21 +252,18 @@ test-e2e: delete-e2e-image-from-kind build-e2e-image load-e2e-image-kind
 	     -e 's|image: quay.io/open-cluster-management/cluster-proxy-e2e:latest|image: $(IMAGE_REGISTRY_NAME)/$(IMAGE_NAME)-e2e:$(IMAGE_TAG)|g' \
 	     test/e2e/env/job.yaml | kubectl apply -f -
 	@./test/e2e/env/wait-for-job.sh cluster-proxy-e2e open-cluster-management-addon 1200
+.PHONY: run-e2e-job
+
+# Run e2e tests in cluster using container image (Kubernetes-native approach)
+# Use LABEL_FILTER to run specific tests, e.g.: make test-e2e LABEL_FILTER="install"
+test-e2e: wait-cluster-proxy-e2e
+	@$(MAKE) run-e2e-job
 .PHONY: test-e2e
 
 # Rapid iteration workflow for e2e tests (cleans up everything first)
 # Use LABEL_FILTER to run specific tests, e.g.: make retest-e2e LABEL_FILTER="connectivity"
-retest-e2e: clean-e2e delete-e2e-image-from-kind build-e2e-image load-e2e-image-kind
-	@echo "Deleting existing e2e test job if present..."
-	@kubectl delete job cluster-proxy-e2e -n open-cluster-management-addon --ignore-not-found
-	@echo "Deploying e2e test job..."
-	@if [ -n "$(LABEL_FILTER)" ]; then \
-		echo "Running tests with label filter: $(LABEL_FILTER)"; \
-	fi
-	@sed -e '/name: LABEL_FILTER/{n;s|value: ""|value: "$(LABEL_FILTER)"|;}' \
-	     -e 's|image: quay.io/open-cluster-management/cluster-proxy-e2e:latest|image: $(IMAGE_REGISTRY_NAME)/$(IMAGE_NAME)-e2e:$(IMAGE_TAG)|g' \
-	     test/e2e/env/job.yaml | kubectl apply -f -
-	@./test/e2e/env/wait-for-job.sh cluster-proxy-e2e open-cluster-management-addon 1200
+retest-e2e: clean-e2e
+	@$(MAKE) test-e2e
 .PHONY: retest-e2e
 
 # Clean up e2e test job and related resources

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,8 +70,6 @@ var (
 )
 
 const (
-	eventuallyTimeout              = 600 // seconds
-	eventuallyInterval             = 30  // seconds
 	hubInstallNamespace            = "open-cluster-management-addon"
 	managedClusterInstallNamespace = "open-cluster-management-cluster-proxy"
 	serviceAccountName             = "cluster-proxy-test"
@@ -125,61 +123,61 @@ var _ = BeforeSuite(func() {
 })
 
 func checkAddonStatus() {
-	var err error
-
 	By("Check resources are running")
-	Eventually(func() error {
-		// deployments on hub is running
-		deployments := []string{
-			"cluster-proxy-addon-manager",
-			"cluster-proxy-addon-user",
-			"cluster-proxy",
-		}
-		for _, deployment := range deployments {
-			fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking deployment: %s in namespace: %s\n", deployment, hubInstallNamespace)
-			d, err := hubKubeClient.AppsV1().Deployments(hubInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
-			if err != nil {
-				fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get deployment %s: %v\n", deployment, err)
-				return err
-			}
-			fmt.Fprintf(GinkgoWriter, "[DEBUG] Deployment %s status - Replicas: %d, Available: %d, Ready: %d, Updated: %d\n",
-				deployment, d.Status.Replicas, d.Status.AvailableReplicas, d.Status.ReadyReplicas, d.Status.UpdatedReplicas)
-			if d.Status.AvailableReplicas < 1 {
-				errMsg := fmt.Errorf("available replicas for %s should >= 1, but get %d", deployment, d.Status.AvailableReplicas)
-				fmt.Fprintf(GinkgoWriter, "[ERROR] %v\n", errMsg)
-				return errMsg
-			}
-			fmt.Fprintf(GinkgoWriter, "[SUCCESS] Deployment %s is ready\n", deployment)
-		}
+	Expect(checkAddonResourcesReady()).ToNot(HaveOccurred())
+}
 
-		// service on hub exist
-		fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking service: cluster-proxy-addon-user in namespace: %s\n", hubInstallNamespace)
-		_, err = hubKubeClient.CoreV1().Services(hubInstallNamespace).Get(context.Background(), "cluster-proxy-addon-user", metav1.GetOptions{})
+func checkAddonResourcesReady() error {
+	// deployments on hub is running
+	deployments := []string{
+		"cluster-proxy-addon-manager",
+		"cluster-proxy-addon-user",
+		"cluster-proxy",
+	}
+	for _, deployment := range deployments {
+		fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking deployment: %s in namespace: %s\n", deployment, hubInstallNamespace)
+		d, err := hubKubeClient.AppsV1().Deployments(hubInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
 		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get service cluster-proxy-addon-user: %v\n", err)
+			fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get deployment %s: %v\n", deployment, err)
 			return err
 		}
-		fmt.Fprintf(GinkgoWriter, "[SUCCESS] Service cluster-proxy-addon-user exists\n")
-
-		// deployment on managedcluster is running
-		fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking deployment: cluster-proxy-proxy-agent in namespace: %s\n", managedClusterInstallNamespace)
-		anpAgent, err := hubKubeClient.AppsV1().Deployments(managedClusterInstallNamespace).Get(context.Background(), "cluster-proxy-proxy-agent", metav1.GetOptions{})
-		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get deployment cluster-proxy-proxy-agent: %v\n", err)
-			return err
-		}
-		fmt.Fprintf(GinkgoWriter, "[DEBUG] Deployment cluster-proxy-proxy-agent status - Replicas: %d, Available: %d, Ready: %d, Updated: %d\n",
-			anpAgent.Status.Replicas, anpAgent.Status.AvailableReplicas, anpAgent.Status.ReadyReplicas, anpAgent.Status.UpdatedReplicas)
-		if anpAgent.Status.AvailableReplicas < 1 {
-			errMsg := fmt.Errorf("available replicas for %s should be more than 1, but get %d", "anp-agent", anpAgent.Status.AvailableReplicas)
+		fmt.Fprintf(GinkgoWriter, "[DEBUG] Deployment %s status - Replicas: %d, Available: %d, Ready: %d, Updated: %d\n",
+			deployment, d.Status.Replicas, d.Status.AvailableReplicas, d.Status.ReadyReplicas, d.Status.UpdatedReplicas)
+		if d.Status.AvailableReplicas < 1 {
+			errMsg := fmt.Errorf("available replicas for %s should >= 1, but get %d", deployment, d.Status.AvailableReplicas)
 			fmt.Fprintf(GinkgoWriter, "[ERROR] %v\n", errMsg)
 			return errMsg
 		}
-		fmt.Fprintf(GinkgoWriter, "[SUCCESS] Deployment cluster-proxy-proxy-agent is ready\n")
+		fmt.Fprintf(GinkgoWriter, "[SUCCESS] Deployment %s is ready\n", deployment)
+	}
 
-		fmt.Fprintf(GinkgoWriter, "[SUCCESS] All resources are running\n")
-		return nil
-	}, eventuallyTimeout, eventuallyInterval).ShouldNot(HaveOccurred())
+	// service on hub exist
+	fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking service: cluster-proxy-addon-user in namespace: %s\n", hubInstallNamespace)
+	_, err := hubKubeClient.CoreV1().Services(hubInstallNamespace).Get(context.Background(), "cluster-proxy-addon-user", metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get service cluster-proxy-addon-user: %v\n", err)
+		return err
+	}
+	fmt.Fprintf(GinkgoWriter, "[SUCCESS] Service cluster-proxy-addon-user exists\n")
+
+	// deployment on managedcluster is running
+	fmt.Fprintf(GinkgoWriter, "[DEBUG] Checking deployment: cluster-proxy-proxy-agent in namespace: %s\n", managedClusterInstallNamespace)
+	anpAgent, err := hubKubeClient.AppsV1().Deployments(managedClusterInstallNamespace).Get(context.Background(), "cluster-proxy-proxy-agent", metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "[ERROR] Failed to get deployment cluster-proxy-proxy-agent: %v\n", err)
+		return err
+	}
+	fmt.Fprintf(GinkgoWriter, "[DEBUG] Deployment cluster-proxy-proxy-agent status - Replicas: %d, Available: %d, Ready: %d, Updated: %d\n",
+		anpAgent.Status.Replicas, anpAgent.Status.AvailableReplicas, anpAgent.Status.ReadyReplicas, anpAgent.Status.UpdatedReplicas)
+	if anpAgent.Status.AvailableReplicas < 1 {
+		errMsg := fmt.Errorf("available replicas for %s should >= 1, but get %d", "cluster-proxy-proxy-agent", anpAgent.Status.AvailableReplicas)
+		fmt.Fprintf(GinkgoWriter, "[ERROR] %v\n", errMsg)
+		return errMsg
+	}
+	fmt.Fprintf(GinkgoWriter, "[SUCCESS] Deployment cluster-proxy-proxy-agent is ready\n")
+
+	fmt.Fprintf(GinkgoWriter, "[SUCCESS] All resources are running\n")
+	return nil
 }
 
 func prepareTestServiceAccount() {

--- a/test/e2e/env/wait-for-cluster-proxy.sh
+++ b/test/e2e/env/wait-for-cluster-proxy.sh
@@ -12,41 +12,32 @@ HUB_NAMESPACE="${HUB_NAMESPACE:-open-cluster-management-addon}"
 AGENT_NAMESPACE="${AGENT_NAMESPACE:-open-cluster-management-cluster-proxy}"
 PLACEMENT_NAME="${PLACEMENT_NAME:-cluster-proxy-placement}"
 
-condition_status() {
-    local resource="$1"
-    local name="$2"
-    local namespace="$3"
-    local condition="$4"
-    local namespace_args=()
-
-    if [ -n "$namespace" ]; then
-        namespace_args=(-n "$namespace")
-    fi
-
-    kubectl get "$resource" "$name" "${namespace_args[@]}" \
-        -o "jsonpath={.status.conditions[?(@.type==\"$condition\")].status}"
-}
-
+# Guards below echo the error and `return 1` inline on purpose: the require_*
+# functions only run inside an `if` condition (set -e suspended), where a
+# `return` in a shared error helper would exit the helper alone and let the
+# caller fall through past the guard.
 require_condition_true() {
     local resource="$1"
     local name="$2"
     local namespace="$3"
     local condition="$4"
+    local namespace_args=()
     local status
 
-    status="$(condition_status "$resource" "$name" "$namespace" "$condition" 2>/dev/null || true)"
+    if [ -n "$namespace" ]; then
+        namespace_args=(-n "$namespace")
+    fi
+
+    status="$(kubectl get "$resource" "$name" "${namespace_args[@]}" \
+        -o "jsonpath={.status.conditions[?(@.type==\"$condition\")].status}" 2>/dev/null || true)"
     if [ "$status" != "True" ]; then
         if [ -n "$namespace" ]; then
-            return_with_error "$resource/$name in namespace $namespace condition $condition is $status"
+            echo "$resource/$name in namespace $namespace condition $condition is $status"
         else
-            return_with_error "$resource/$name condition $condition is $status"
+            echo "$resource/$name condition $condition is $status"
         fi
+        return 1
     fi
-}
-
-return_with_error() {
-    echo "$1"
-    return 1
 }
 
 require_deployment_ready() {
@@ -58,7 +49,8 @@ require_deployment_ready() {
 
     fields="$(kubectl get deployment "$name" -n "$namespace" -o jsonpath='{.metadata.generation}{"\n"}{.status.observedGeneration}{"\n"}{.status.replicas}{"\n"}{.status.readyReplicas}{"\n"}{.status.updatedReplicas}{"\n"}{.status.availableReplicas}{"\n"}{.status.unavailableReplicas}{"\n"}{.spec.replicas}{"\n"}' 2>/dev/null || true)"
     if [ -z "$fields" ]; then
-        return_with_error "deployment/$name in namespace $namespace does not exist"
+        echo "deployment/$name in namespace $namespace does not exist"
+        return 1
     fi
 
     mapfile -t deployment_fields <<<"$fields"
@@ -71,16 +63,9 @@ require_deployment_ready() {
     unavailable="${deployment_fields[6]:-0}"
     spec_replicas="${deployment_fields[7]:-1}"
 
-    if [ -z "$observed" ]; then observed=0; fi
-    if [ -z "$replicas" ]; then replicas=0; fi
-    if [ -z "$ready" ]; then ready=0; fi
-    if [ -z "$updated" ]; then updated=0; fi
-    if [ -z "$available" ]; then available=0; fi
-    if [ -z "$unavailable" ]; then unavailable=0; fi
-    if [ -z "$spec_replicas" ]; then spec_replicas=1; fi
-
     if [ "$observed" -lt "$generation" ]; then
-        return_with_error "deployment/$name in namespace $namespace has not observed generation $generation"
+        echo "deployment/$name in namespace $namespace has not observed generation $generation"
+        return 1
     fi
 
     if [ "$replicas" -ne "$spec_replicas" ] ||
@@ -88,7 +73,8 @@ require_deployment_ready() {
         [ "$updated" -ne "$spec_replicas" ] ||
         [ "$available" -ne "$spec_replicas" ] ||
         [ "$unavailable" -ne 0 ]; then
-        return_with_error "deployment/$name in namespace $namespace is not ready: replicas=$replicas ready=$ready updated=$updated available=$available unavailable=$unavailable expected=$spec_replicas"
+        echo "deployment/$name in namespace $namespace is not ready: replicas=$replicas ready=$ready updated=$updated available=$available unavailable=$unavailable expected=$spec_replicas"
+        return 1
     fi
 }
 
@@ -96,37 +82,48 @@ require_service() {
     local namespace="$1"
     local name="$2"
 
-    kubectl get service "$name" -n "$namespace" >/dev/null 2>&1 ||
-        return_with_error "service/$name in namespace $namespace does not exist"
+    if ! kubectl get service "$name" -n "$namespace" >/dev/null 2>&1; then
+        echo "service/$name in namespace $namespace does not exist"
+        return 1
+    fi
+}
+
+require_clustermanagementaddon() {
+    if ! kubectl get clustermanagementaddon cluster-proxy >/dev/null 2>&1; then
+        echo "clustermanagementaddon/cluster-proxy does not exist"
+        return 1
+    fi
 }
 
 require_cluster_proxy_configuration() {
     local condition
 
-    kubectl get managedproxyconfiguration cluster-proxy >/dev/null 2>&1 ||
-        return_with_error "managedproxyconfiguration/cluster-proxy does not exist"
+    if ! kubectl get managedproxyconfiguration cluster-proxy >/dev/null 2>&1; then
+        echo "managedproxyconfiguration/cluster-proxy does not exist"
+        return 1
+    fi
 
     for condition in ProxyServerDeployed ProxyServerSecretSigned AgentServerSecretSigned UserServerSecretSigned; do
-        require_condition_true managedproxyconfiguration cluster-proxy "" "$condition"
+        require_condition_true managedproxyconfiguration cluster-proxy "" "$condition" || return 1
     done
 }
 
 require_placement_decision() {
     local clusters
 
-    kubectl get placement "$PLACEMENT_NAME" -n "$HUB_NAMESPACE" >/dev/null 2>&1 ||
-        return_with_error "placement/$PLACEMENT_NAME in namespace $HUB_NAMESPACE does not exist"
+    if ! kubectl get placement "$PLACEMENT_NAME" -n "$HUB_NAMESPACE" >/dev/null 2>&1; then
+        echo "placement/$PLACEMENT_NAME in namespace $HUB_NAMESPACE does not exist"
+        return 1
+    fi
 
     clusters="$(kubectl get placementdecision -n "$HUB_NAMESPACE" \
         -l "cluster.open-cluster-management.io/placement=$PLACEMENT_NAME" \
         -o 'jsonpath={range .items[*].status.decisions[*]}{.clusterName}{"\n"}{end}' 2>/dev/null || true)"
-    if [ -z "$clusters" ]; then
-        clusters="$(kubectl get placementdecision -n "$HUB_NAMESPACE" \
-            -o 'jsonpath={range .items[*].status.decisions[*]}{.clusterName}{"\n"}{end}' 2>/dev/null || true)"
-    fi
 
-    echo "$clusters" | grep -Fxq "$MANAGED_CLUSTER_NAME" ||
-        return_with_error "placement/$PLACEMENT_NAME has not selected managed cluster $MANAGED_CLUSTER_NAME"
+    if ! echo "$clusters" | grep -Fxq "$MANAGED_CLUSTER_NAME"; then
+        echo "placement/$PLACEMENT_NAME has not selected managed cluster $MANAGED_CLUSTER_NAME"
+        return 1
+    fi
 }
 
 require_cluster_proxy_ready() {
@@ -139,8 +136,7 @@ require_cluster_proxy_ready() {
         require_deployment_ready "$HUB_NAMESPACE" cluster-proxy &&
         require_service "$HUB_NAMESPACE" cluster-proxy-addon-user &&
         require_condition_true managedcluster "$MANAGED_CLUSTER_NAME" "" ManagedClusterConditionAvailable &&
-        { kubectl get clustermanagementaddon cluster-proxy >/dev/null 2>&1 ||
-            return_with_error "clustermanagementaddon/cluster-proxy does not exist"; } &&
+        require_clustermanagementaddon &&
         require_placement_decision &&
         require_cluster_proxy_configuration &&
         require_condition_true managedclusteraddon cluster-proxy "$MANAGED_CLUSTER_NAME" Available &&

--- a/test/e2e/env/wait-for-cluster-proxy.sh
+++ b/test/e2e/env/wait-for-cluster-proxy.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+# wait-for-cluster-proxy.sh - Wait for the e2e cluster-proxy installation to converge.
+# Usage: wait-for-cluster-proxy.sh [timeout-seconds]
+
+set -euo pipefail
+
+TIMEOUT="${1:-600}"
+INTERVAL=5
+MANAGED_CLUSTER_NAME="${MANAGED_CLUSTER_NAME:-loopback}"
+HUB_NAMESPACE="${HUB_NAMESPACE:-open-cluster-management-addon}"
+AGENT_NAMESPACE="${AGENT_NAMESPACE:-open-cluster-management-cluster-proxy}"
+PLACEMENT_NAME="${PLACEMENT_NAME:-cluster-proxy-placement}"
+
+condition_status() {
+    local resource="$1"
+    local name="$2"
+    local namespace="$3"
+    local condition="$4"
+    local namespace_args=()
+
+    if [ -n "$namespace" ]; then
+        namespace_args=(-n "$namespace")
+    fi
+
+    kubectl get "$resource" "$name" "${namespace_args[@]}" \
+        -o "jsonpath={.status.conditions[?(@.type==\"$condition\")].status}"
+}
+
+require_condition_true() {
+    local resource="$1"
+    local name="$2"
+    local namespace="$3"
+    local condition="$4"
+    local status
+
+    status="$(condition_status "$resource" "$name" "$namespace" "$condition" 2>/dev/null || true)"
+    if [ "$status" != "True" ]; then
+        if [ -n "$namespace" ]; then
+            return_with_error "$resource/$name in namespace $namespace condition $condition is $status"
+        else
+            return_with_error "$resource/$name condition $condition is $status"
+        fi
+    fi
+}
+
+return_with_error() {
+    echo "$1"
+    return 1
+}
+
+require_deployment_ready() {
+    local namespace="$1"
+    local name="$2"
+    local fields
+    local -a deployment_fields
+    local generation observed replicas ready updated available unavailable spec_replicas
+
+    fields="$(kubectl get deployment "$name" -n "$namespace" -o jsonpath='{.metadata.generation}{"\n"}{.status.observedGeneration}{"\n"}{.status.replicas}{"\n"}{.status.readyReplicas}{"\n"}{.status.updatedReplicas}{"\n"}{.status.availableReplicas}{"\n"}{.status.unavailableReplicas}{"\n"}{.spec.replicas}{"\n"}' 2>/dev/null || true)"
+    if [ -z "$fields" ]; then
+        return_with_error "deployment/$name in namespace $namespace does not exist"
+    fi
+
+    mapfile -t deployment_fields <<<"$fields"
+    generation="${deployment_fields[0]:-0}"
+    observed="${deployment_fields[1]:-0}"
+    replicas="${deployment_fields[2]:-0}"
+    ready="${deployment_fields[3]:-0}"
+    updated="${deployment_fields[4]:-0}"
+    available="${deployment_fields[5]:-0}"
+    unavailable="${deployment_fields[6]:-0}"
+    spec_replicas="${deployment_fields[7]:-1}"
+
+    if [ -z "$observed" ]; then observed=0; fi
+    if [ -z "$replicas" ]; then replicas=0; fi
+    if [ -z "$ready" ]; then ready=0; fi
+    if [ -z "$updated" ]; then updated=0; fi
+    if [ -z "$available" ]; then available=0; fi
+    if [ -z "$unavailable" ]; then unavailable=0; fi
+    if [ -z "$spec_replicas" ]; then spec_replicas=1; fi
+
+    if [ "$observed" -lt "$generation" ]; then
+        return_with_error "deployment/$name in namespace $namespace has not observed generation $generation"
+    fi
+
+    if [ "$replicas" -ne "$spec_replicas" ] ||
+        [ "$ready" -ne "$spec_replicas" ] ||
+        [ "$updated" -ne "$spec_replicas" ] ||
+        [ "$available" -ne "$spec_replicas" ] ||
+        [ "$unavailable" -ne 0 ]; then
+        return_with_error "deployment/$name in namespace $namespace is not ready: replicas=$replicas ready=$ready updated=$updated available=$available unavailable=$unavailable expected=$spec_replicas"
+    fi
+}
+
+require_service() {
+    local namespace="$1"
+    local name="$2"
+
+    kubectl get service "$name" -n "$namespace" >/dev/null 2>&1 ||
+        return_with_error "service/$name in namespace $namespace does not exist"
+}
+
+require_cluster_proxy_configuration() {
+    local condition
+
+    kubectl get managedproxyconfiguration cluster-proxy >/dev/null 2>&1 ||
+        return_with_error "managedproxyconfiguration/cluster-proxy does not exist"
+
+    for condition in ProxyServerDeployed ProxyServerSecretSigned AgentServerSecretSigned UserServerSecretSigned; do
+        require_condition_true managedproxyconfiguration cluster-proxy "" "$condition"
+    done
+}
+
+require_placement_decision() {
+    local clusters
+
+    kubectl get placement "$PLACEMENT_NAME" -n "$HUB_NAMESPACE" >/dev/null 2>&1 ||
+        return_with_error "placement/$PLACEMENT_NAME in namespace $HUB_NAMESPACE does not exist"
+
+    clusters="$(kubectl get placementdecision -n "$HUB_NAMESPACE" \
+        -l "cluster.open-cluster-management.io/placement=$PLACEMENT_NAME" \
+        -o 'jsonpath={range .items[*].status.decisions[*]}{.clusterName}{"\n"}{end}' 2>/dev/null || true)"
+    if [ -z "$clusters" ]; then
+        clusters="$(kubectl get placementdecision -n "$HUB_NAMESPACE" \
+            -o 'jsonpath={range .items[*].status.decisions[*]}{.clusterName}{"\n"}{end}' 2>/dev/null || true)"
+    fi
+
+    echo "$clusters" | grep -Fxq "$MANAGED_CLUSTER_NAME" ||
+        return_with_error "placement/$PLACEMENT_NAME has not selected managed cluster $MANAGED_CLUSTER_NAME"
+}
+
+require_cluster_proxy_ready() {
+    # Short-circuit on the first failing check: this function runs inside an
+    # `if` (set -e suspended), so without &&-chaining every check would run on
+    # each poll and the function would report the last check's status instead
+    # of failing fast.
+    require_deployment_ready "$HUB_NAMESPACE" cluster-proxy-addon-manager &&
+        require_deployment_ready "$HUB_NAMESPACE" cluster-proxy-addon-user &&
+        require_deployment_ready "$HUB_NAMESPACE" cluster-proxy &&
+        require_service "$HUB_NAMESPACE" cluster-proxy-addon-user &&
+        require_condition_true managedcluster "$MANAGED_CLUSTER_NAME" "" ManagedClusterConditionAvailable &&
+        { kubectl get clustermanagementaddon cluster-proxy >/dev/null 2>&1 ||
+            return_with_error "clustermanagementaddon/cluster-proxy does not exist"; } &&
+        require_placement_decision &&
+        require_cluster_proxy_configuration &&
+        require_condition_true managedclusteraddon cluster-proxy "$MANAGED_CLUSTER_NAME" Available &&
+        require_deployment_ready "$AGENT_NAMESPACE" cluster-proxy-proxy-agent
+}
+
+echo "Waiting for cluster-proxy e2e installation to be ready..."
+echo "Managed cluster: $MANAGED_CLUSTER_NAME"
+echo "Hub namespace: $HUB_NAMESPACE"
+echo "Agent namespace: $AGENT_NAMESPACE"
+echo "Timeout: ${TIMEOUT}s"
+echo ""
+
+start_time="$(date +%s)"
+deadline=$((start_time + TIMEOUT))
+output=""
+iteration=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    iteration=$((iteration + 1))
+    if output="$(require_cluster_proxy_ready 2>&1)"; then
+        echo "cluster-proxy e2e installation is ready"
+        exit 0
+    fi
+
+    if [ $((iteration % 6)) -eq 0 ]; then
+        elapsed=$(($(date +%s) - start_time))
+        echo "[$(date '+%H:%M:%S')] Still waiting for cluster-proxy readiness (${elapsed}s elapsed)"
+        echo "$output"
+    fi
+
+    sleep "$INTERVAL"
+done
+
+echo ""
+echo "cluster-proxy e2e installation was not ready after ${TIMEOUT}s"
+if [ -n "$output" ]; then
+    echo "Last readiness error:"
+    echo "$output"
+fi
+exit 1


### PR DESCRIPTION
## Summary
- include the same GitHub Actions pin updates as PR #323
- add a cluster-proxy readiness gate before creating the e2e Kubernetes Job
- wait for hub deployments/service, managed cluster availability, placement decision selection, ManagedProxyConfiguration conditions, ManagedClusterAddOn availability, and proxy-agent rollout
- keep shared diagnostics for readiness and e2e Job failures
- turn the e2e BeforeSuite addon check into an immediate sanity check instead of a long install wait

## Why
PR #323 failed because the e2e Job started before the cluster-proxy addon installation had converged. The visible failure was `cluster-proxy-proxy-agent` missing after the BeforeSuite timeout, but the harness was mixing install readiness with test execution.

This moves environment convergence into the CI/setup layer and fails there with OCM/addon diagnostics when installation does not become ready. The test suite then only validates that its prerequisite is still present before running functional tests.

## Validation
- `bash -n test/e2e/env/diagnostics.sh test/e2e/env/wait-for-cluster-proxy.sh test/e2e/env/wait-for-job.sh`
- `go test ./test/e2e -run "^$"`
- `make test-helm`
- `make -n test-e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test stability by waiting for cluster-proxy readiness before starting tests.
  * Strengthened readiness validation by checking deployments, services, cluster-proxy configuration, and placement decisions with clearer failure reporting.
* **Tests**
  * Streamlined end-to-end test and retest workflows to consolidate image preparation and ensure consistent readiness sequencing.
  * Updated addon readiness verification to fail immediately with direct readiness assertions (reduced polling-based flakiness).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->