### PR TITLE
:seedling: use test-scoped HTTP request contexts

### DIFF
--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -83,10 +83,11 @@ func TestProcessAuthentication_ManagedClusterToken(t *testing.T) {
 		}),
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer mc-token")
 
-	if err := s.processAuthentication(context.Background(), req); err != nil {
+	if err := s.processAuthentication(ctx, req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -115,10 +116,11 @@ func TestProcessAuthentication_HubServiceAccountToken(t *testing.T) {
 		},
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer hub-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,10 +147,11 @@ func TestProcessAuthentication_UnauthenticatedToken(t *testing.T) {
 		}),
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer invalid-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err == nil {
 		t.Fatal("expected authentication error")
 	}
@@ -163,14 +166,15 @@ func TestProcessHubUser_RegularUser(t *testing.T) {
 			return "fake-sa-token", nil
 		},
 	}
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 
 	hubUser := &user.DefaultInfo{
 		Name:   "admin@example.com",
 		Groups: []string{"system:authenticated", "admins"},
 	}
 
-	if err := s.processHubUser(context.Background(), req, hubUser); err != nil {
+	if err := s.processHubUser(ctx, req, hubUser); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -191,14 +195,15 @@ func TestProcessHubUser_ServiceAccount(t *testing.T) {
 			return "fake-sa-token", nil
 		},
 	}
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 
 	hubUser := &user.DefaultInfo{
 		Name:   "system:serviceaccount:proxy-test:proxy-bench",
 		Groups: []string{"system:serviceaccounts", "system:authenticated"},
 	}
 
-	if err := s.processHubUser(context.Background(), req, hubUser); err != nil {
+	if err := s.processHubUser(ctx, req, hubUser); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -378,10 +383,11 @@ func TestProcessAuthentication_GetImpersonateTokenError(t *testing.T) {
 		},
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer hub-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err == nil {
 		t.Fatal("expected error from getImpersonateTokenFunc")
 	}
@@ -402,10 +408,11 @@ func TestProcessAuthentication_ManagedClusterFatalError(t *testing.T) {
 		}),
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err == nil {
 		t.Fatal("expected fatal error when managed cluster auth has infrastructure failure")
 	}
@@ -436,10 +443,11 @@ func TestProcessAuthentication_OpenShiftTokenReviewError_FallsBackToHub(t *testi
 		},
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer hub-only-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -464,10 +472,11 @@ func TestProcessAuthentication_HubAuthError(t *testing.T) {
 			}),
 	}
 
-	req, _ := http.NewRequest("GET", "https://example.com/api", nil)
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
 
-	err := s.processAuthentication(context.Background(), req)
+	err := s.processAuthentication(ctx, req)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/test/e2e/connect_test.go
+++ b/test/e2e/connect_test.go
@@ -227,11 +227,11 @@ var _ = Describe("Requests through Cluster-Proxy", Label("serviceproxy", "connec
 
 	// Note: hello-world service is deployed during environment initialization in test/e2e/env/init.sh
 	Describe("Access hello-world service", Label("service-access"), func() {
-		It("should return hello-world with http code 200", Label("hello-world", "http"), func() {
+		It("should return hello-world with http code 200", Label("hello-world", "http"), func(ctx SpecContext) {
 			targetHost := fmt.Sprintf(`https://%s/%s/api/v1/namespaces/default/services/http:hello-world:8000/proxy-service/index.html`, userServerServiceAddress, managedClusterName)
 			fmt.Println("The targetHost: ", targetHost)
 
-			req, err := http.NewRequest("GET", targetHost, nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", targetHost, nil)
 			Expect(err).To(BeNil())
 
 			resp, err := clusterProxyHttpClient.Do(req)
@@ -258,11 +258,11 @@ var _ = Describe("Requests through Cluster-Proxy", Label("serviceproxy", "connec
 	// without including error details in the response body. Therefore, we accept 502 status
 	// as success since it indicates the request was routed but TLS verification failed.
 	Describe("Access hello-world-https service", Label("service-access-https"), func() {
-		It("should route request to hello-world-https backend service", Label("hello-world-https", "https"), func() {
+		It("should route request to hello-world-https backend service", Label("hello-world-https", "https"), func(ctx SpecContext) {
 			targetHost := fmt.Sprintf(`https://%s/%s/api/v1/namespaces/default/services/https:hello-world-https:8443/proxy-service/index.html`, userServerServiceAddress, managedClusterName)
 			fmt.Println("The targetHost: ", targetHost)
 
-			req, err := http.NewRequest("GET", targetHost, nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", targetHost, nil)
 			Expect(err).To(BeNil())
 
 			resp, err := clusterProxyHttpClient.Do(req)


### PR DESCRIPTION
## Summary

Use test-scoped contexts for HTTP requests in the existing service-proxy unit tests and Ginkgo connectivity tests.
