### PR TITLE
:sparkles: Add opt-in NetworkPolicies for hub and managed workloads

### DIFF
--- a/charts/cluster-proxy/templates/cluster-proxy-addon-manager-networkpolicy.yaml
+++ b/charts/cluster-proxy/templates/cluster-proxy-addon-manager-networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for cluster-proxy addon-manager, then allow DNS and
+# Kubernetes API egress. Manager has no Service/ingress.
+# Peers are port-based (empty "to") for portability across Kubernetes vendors.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-addon-manager-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      component: cluster-proxy-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/charts/cluster-proxy/templates/cluster-proxy-addon-user-networkpolicy.yaml
+++ b/charts/cluster-proxy/templates/cluster-proxy-addon-user-networkpolicy.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.networkPolicies.enabled .Values.enableServiceProxy }}
+# Purpose: Default-deny for cluster-proxy-addon-user (user-server), then allow
+# ingress on serving port 9092 (empty "from" for ingress controllers / in-cluster
+# clients), plus DNS, API, and ANP client egress to proxy-server on 8090.
+# Probe port 8000 is omitted (kubelet probes are not blocked by NetworkPolicy).
+# Peers are port-based where destinations are not selectable across vendors.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-addon-user-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      component: cluster-proxy-addon-user
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Empty from: port-based allow (ingress controllers / in-cluster clients).
+  - ports:
+    - protocol: TCP
+      port: 9092
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # ANP client → same-namespace proxy-server
+  - to:
+    - podSelector:
+        matchLabels:
+          proxy.open-cluster-management.io/component-name: proxy-server
+    ports:
+    - protocol: TCP
+      port: 8090
+{{- end }}

--- a/charts/cluster-proxy/templates/cluster-proxy-proxy-server-networkpolicy.yaml
+++ b/charts/cluster-proxy/templates/cluster-proxy-proxy-server-networkpolicy.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for ANP proxy-server pods created via
+# ManagedProxyConfiguration, then allow ingress on 8090/8091 (empty "from" for
+# ingress controllers / tunnel clients), same-namespace user-server on 8090,
+# and DNS + API egress.
+# Peers are port-based where destinations are not selectable across vendors.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-proxy-server-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      proxy.open-cluster-management.io/component-name: proxy-server
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Empty from: port-based allow (ingress controllers / ANP agents).
+  - ports:
+    - protocol: TCP
+      port: 8090
+    - protocol: TCP
+      port: 8091
+  # Reciprocal allow for cluster-proxy-addon-user ANP client → proxy-server :8090
+  - from:
+    - podSelector:
+        matchLabels:
+          component: cluster-proxy-addon-user
+    ports:
+    - protocol: TCP
+      port: 8090
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -34,6 +34,7 @@ spec:
             - --signer-secret-namespace={{ .Release.Namespace }}
             - --enable-kube-api-proxy={{ .Values.enableKubeApiProxy }}
             - --enable-service-proxy={{ .Values.enableServiceProxy }}
+            - --enable-network-policies={{ .Values.networkPolicies.enabled }}
             - --image-pull-policy={{ .Values.proxyServer.imagePullPolicy }}
             - --agent-install-namespace={{ .Values.spokeAddonNamespace }}
             {{- if .Values.featureGates }}

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -52,3 +52,10 @@ userServer:
   # Additional SANs for the certificate (e.g., external hostnames)
   # Example: ["user-server.example.com", "10.0.0.100"]
   additionalSANs: []
+
+# Opt-in NetworkPolicies for hub workloads (addon-manager, user-server, ANP
+# proxy-server) and for the managed-cluster proxy-agent (via manager flag
+# --enable-network-policies). Default false so community installs are unchanged.
+# Policies use port-based peers for portability across Kubernetes vendors.
+networkPolicies:
+  enabled: false

--- a/cmd/addon-manager/main.go
+++ b/cmd/addon-manager/main.go
@@ -80,6 +80,7 @@ func main() {
 	var signerSecretNamespace, signerSecretName string
 	var enableKubeAPIProxy bool
 	var enableServiceProxy bool
+	var enableNetworkPolicies bool
 	var imagePullPolicy string
 	var featureGates map[string]bool
 
@@ -100,6 +101,8 @@ func main() {
 		"The name of the addon agent's image")
 	flag.BoolVar(&enableKubeAPIProxy, "enable-kube-api-proxy", true, "Enable proxy to agent kube-apiserver")
 	flag.BoolVar(&enableServiceProxy, "enable-service-proxy", true, "Enable service proxy")
+	flag.BoolVar(&enableNetworkPolicies, "enable-network-policies", false,
+		"Enable NetworkPolicies for the managed-cluster proxy-agent")
 	flag.StringVar(&config.DefaultAddonInstallNamespace, "agent-install-namespace", config.DefaultAddonInstallNamespace,
 		"The default namespace to install the addon agents.")
 	flag.StringVar(&imagePullPolicy, "image-pull-policy", string(corev1.PullIfNotPresent), "The image pull policy for the addon manager")
@@ -234,6 +237,7 @@ func main() {
 		nativeClient,
 		enableKubeAPIProxy,
 		enableServiceProxy,
+		enableNetworkPolicies,
 		addonClient,
 	)
 	if err != nil {

--- a/pkg/proxyagent/agent/additional_values.go
+++ b/pkg/proxyagent/agent/additional_values.go
@@ -32,6 +32,7 @@ func GetClusterProxyAdditionalValueFunc(
 	nativeClient kubernetes.Interface,
 	signerNamespace string,
 	enableServiceProxy bool,
+	enableNetworkPolicies bool,
 ) addonfactory.GetValuesFunc {
 	return func(cluster *clusterv1.ManagedCluster,
 		addon *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
@@ -71,6 +72,9 @@ func GetClusterProxyAdditionalValueFunc(
 			"image":           image,
 			"tag":             tag,
 			"proxyAgentImage": clusterProxyAddonImage,
+			"networkPolicies": map[string]interface{}{
+				"enabled": enableNetworkPolicies,
+			},
 		}
 
 		// get node selector

--- a/pkg/proxyagent/agent/agent.go
+++ b/pkg/proxyagent/agent/agent.go
@@ -55,6 +55,7 @@ func NewAgentAddon(
 	nativeClient kubernetes.Interface,
 	enableKubeApiProxy bool, //nolint:revive // parameter name is part of the public API
 	enableServiceProxy bool,
+	enableNetworkPolicies bool,
 	addonClient addonclient.Interface) (agent.AgentAddon, error) {
 	caCertData, caKeyData, err := signer.CA().Config.GetPEMBytes()
 	if err != nil {
@@ -129,7 +130,7 @@ func NewAgentAddon(
 		WithAgentDeployTriggerClusterFilter(utils.ClusterImageRegistriesAnnotationChanged).
 		WithGetValuesFuncs(
 			GetClusterProxyValueFunc(runtimeClient, nativeClient, signerNamespace, caCertData, enableKubeApiProxy),
-			GetClusterProxyAdditionalValueFunc(runtimeClient, nativeClient, signerNamespace, enableServiceProxy),
+			GetClusterProxyAdditionalValueFunc(runtimeClient, nativeClient, signerNamespace, enableServiceProxy, enableNetworkPolicies),
 			addonfactory.GetAddOnDeploymentConfigValues(
 				utils.NewAddOnDeploymentConfigGetter(addonClient),
 				toAgentAddOnChartValues(caCertData),

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -21,6 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	csrv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +149,7 @@ func TestAgentAddonRegistrationOption(t *testing.T) {
 				nil,
 				fakeKubeClient,
 				true,
+				false,
 				false,
 				nil,
 			)
@@ -283,6 +285,7 @@ func TestNewAgentAddon(t *testing.T) {
 		kubeObjs                []runtime.Object
 		enableKubeApiProxy      bool
 		enableServiceProxy      bool
+		enableNetworkPolicies   bool
 		expectedErrorMsg        string
 		verifyManifests         func(t *testing.T, manifests []runtime.Object)
 	}{
@@ -439,6 +442,61 @@ func TestNewAgentAddon(t *testing.T) {
 					assert.NotNil(t, serviceProxy.ReadinessProbe) &&
 					assert.NotNil(t, serviceProxy.ReadinessProbe.TCPSocket) {
 					assert.Equal(t, int32(constant.ServiceProxyPort), serviceProxy.ReadinessProbe.TCPSocket.Port.IntVal)
+				}
+			},
+		},
+		{
+			name:    "port forward proxy server with network policies",
+			cluster: newCluster(clusterName, true),
+			addon: func() *addonv1beta1.ManagedClusterAddOn {
+				addOn := newAddOn(addOnName, clusterName)
+				addOn.Status.ConfigReferences = []addonv1beta1.ConfigReference{newManagedProxyConfigReference(managedProxyConfigName)}
+				return addOn
+			}(),
+			managedProxyConfig:      newManagedProxyConfig(managedProxyConfigName, proxyv1alpha1.EntryPointTypePortForward),
+			addOndDeploymentConfigs: []runtime.Object{},
+			kubeObjs:                []runtime.Object{},
+			enableKubeApiProxy:      true,
+			enableNetworkPolicies:   true,
+			verifyManifests: func(t *testing.T, manifests []runtime.Object) {
+				expected := append([]string{}, expectedManifestNames...)
+				expected = append(expected, "cluster-proxy-proxy-agent-network-policy")
+				assert.Len(t, manifests, len(expected))
+				assert.ElementsMatch(t, expected, manifestNames(manifests))
+				np := getAgentNetworkPolicy(manifests)
+				if assert.NotNil(t, np) {
+					assert.False(t, networkPolicyHasAllowAllEgress(np),
+						"without service-proxy, agent NP must not allow all egress")
+				}
+			},
+		},
+		{
+			name:    "network policies with service proxy allows arbitrary backend egress",
+			cluster: newCluster(clusterName, true),
+			addon: func() *addonv1beta1.ManagedClusterAddOn {
+				addOn := newAddOn(addOnName, clusterName)
+				addOn.Status.ConfigReferences = []addonv1beta1.ConfigReference{newManagedProxyConfigReference(managedProxyConfigName)}
+				return addOn
+			}(),
+			managedProxyConfig:      newManagedProxyConfig(managedProxyConfigName, proxyv1alpha1.EntryPointTypePortForward),
+			addOndDeploymentConfigs: []runtime.Object{},
+			kubeObjs:                []runtime.Object{},
+			enableKubeApiProxy:      true,
+			enableServiceProxy:      true,
+			enableNetworkPolicies:   true,
+			verifyManifests: func(t *testing.T, manifests []runtime.Object) {
+				expected := append([]string{}, expectedManifestNamesWithServiceProxy...)
+				expected = append(expected, "cluster-proxy-proxy-agent-network-policy")
+				assert.Len(t, manifests, len(expected))
+				assert.ElementsMatch(t, expected, manifestNames(manifests))
+				np := getAgentNetworkPolicy(manifests)
+				if assert.NotNil(t, np) {
+					// Fixed allowlist covers 443/6443/entrypoint but not e.g. :8080;
+					// service-proxy backends use Cluster-Proxy-Port at request time.
+					assert.False(t, networkPolicyAllowsEgressTCPPort(np, 8080),
+						"fixed allowlist alone must not cover backend port 8080")
+					assert.True(t, networkPolicyHasAllowAllEgress(np),
+						"service-proxy requires allow-all egress exemption for arbitrary backends")
 				}
 			},
 		},
@@ -728,6 +786,7 @@ func TestNewAgentAddon(t *testing.T) {
 				fakeKubeClient,
 				c.enableKubeApiProxy,
 				c.enableServiceProxy,
+				c.enableNetworkPolicies,
 				fakeAddonClient,
 			)
 			assert.NoError(t, err)
@@ -1081,6 +1140,53 @@ func getAgentDeployment(manifests []runtime.Object) *appsv1.Deployment {
 	}
 
 	return nil
+}
+
+func getAgentNetworkPolicy(manifests []runtime.Object) *networkingv1.NetworkPolicy {
+	for _, manifest := range manifests {
+		if np, ok := manifest.(*networkingv1.NetworkPolicy); ok {
+			if np.Name == "cluster-proxy-proxy-agent-network-policy" {
+				return np
+			}
+		}
+	}
+	return nil
+}
+
+// networkPolicyHasAllowAllEgress reports whether any egress rule matches all
+// destinations and ports (empty to and empty ports), used as the service-proxy
+// backend exemption for arbitrary Cluster-Proxy-Port targets.
+func networkPolicyHasAllowAllEgress(np *networkingv1.NetworkPolicy) bool {
+	if np == nil {
+		return false
+	}
+	for _, rule := range np.Spec.Egress {
+		if len(rule.To) == 0 && len(rule.Ports) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// networkPolicyAllowsEgressTCPPort is true only when a port-restricted egress
+// rule (non-empty ports) explicitly lists the TCP port — not via allow-all.
+func networkPolicyAllowsEgressTCPPort(np *networkingv1.NetworkPolicy, port int32) bool {
+	if np == nil {
+		return false
+	}
+	for _, rule := range np.Spec.Egress {
+		if len(rule.Ports) == 0 {
+			continue
+		}
+		for _, p := range rule.Ports {
+			if p.Port != nil && p.Port.IntVal == port {
+				if p.Protocol == nil || *p.Protocol == corev1.ProtocolTCP {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func getDeploymentContainer(deploy *appsv1.Deployment, name string) *corev1.Container {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-networkpolicy.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-networkpolicy.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for cluster-proxy-proxy-agent on the managed cluster,
+# then allow required ingress/egress for the tunnel.
+# Gaps: egress peers are port-only (empty "to") because hub Route/LB and
+# kube-apiserver addresses are not selectable by NetworkPolicy; hostnames
+# cannot be used. DNS covers :53 and :5353 for broad distribution support.
+# When enableServiceProxy is true, an allow-all egress rule is added because
+# service-proxy dials arbitrary Service backends from request headers
+# (Cluster-Proxy-Namespace / Cluster-Proxy-Port / Cluster-Proxy-Service);
+# those targets are not known at chart render time.
+# Enabled when the hub addon-manager runs with --enable-network-policies=true
+# (from charts/cluster-proxy values networkPolicies.enabled).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-proxy-proxy-agent-network-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    open-cluster-management.io/addon: cluster-proxy
+    proxy.open-cluster-management.io/component-name: proxy-agent
+spec:
+  podSelector:
+    matchLabels:
+      open-cluster-management.io/addon: cluster-proxy
+      proxy.open-cluster-management.io/component-name: proxy-agent
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # service-proxy health / readiness and local proxied service traffic
+  - ports:
+    - protocol: TCP
+      port: 8000
+    - protocol: TCP
+      port: 7443
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Hub ingress (:443), hub/spoke kubeconfig API (:6443), ANP entrypoint
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: {{ .Values.serviceEntryPointPort }}
+  {{- if .Values.enableServiceProxy }}
+  # Service-proxy backend exemption: Cluster-Proxy-Namespace/Port identify
+  # arbitrary in-cluster Services (e.g. helloworld.default.svc:8080) that
+  # cannot be allow-listed statically.
+  - {}
+  {{- end }}
+{{- end }}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -50,5 +50,11 @@ proxyConfig:
 
 enableImpersonation: "true"
 
+# Opt-in NetworkPolicy for the spoke proxy-agent Deployment.
+# Set by the hub addon-manager from --enable-network-policies
+# (charts/cluster-proxy values networkPolicies.enabled).
+networkPolicies:
+  enabled: false
+
 global:
   resourceRequirements: []


### PR DESCRIPTION
## Summary
- Adds opt-in Helm `networkPolicies.enabled` (default `false`) that renders NetworkPolicies for hub addon-manager, user-server (when `enableServiceProxy`), and ANP proxy-server.
- Passes the same toggle to the addon-manager as `--enable-network-policies`, which injects agent chart values so the managed-cluster proxy-agent NetworkPolicy is included in ManifestWorks.
- Policies are **vendor-neutral**: peers are port-based (empty `from`/`to` where needed) so the same manifests work across Kubernetes distributions. Hub and spoke policies share that portable style (DNS :53/:5353, API :443/:6443, service ports). No OpenShift-specific selectors (e.g. `openshift-dns`, ingress `policy-group`).
- When service-proxy is also enabled, the agent NetworkPolicy adds an allow-all egress exemption so arbitrary `Cluster-Proxy-Port` backends are not blocked.

## Test plan
- [x] `go test ./pkg/proxyagent/agent/`
- [x] `helm template` with `networkPolicies.enabled=true` shows hub NPs and `--enable-network-policies=true` on the manager
- [x] Install/upgrade chart with `networkPolicies.enabled=true` and confirm hub NPs are created
- [x] Confirm managed-cluster proxy-agent NetworkPolicy appears after addon reconcile
- [x] Leave default `false` and confirm no NetworkPolicies are rendered/deployed