### PR TITLE
:bug: strip client Impersonate-* headers in service-proxy

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/token/cache"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -352,6 +353,24 @@ func (s *serviceProxy) readImpersonateTokenFromFile() (string, error) {
 	return string(token), nil
 }
 
+// stripClientImpersonationHeaders removes any client-supplied impersonation headers.
+// Without this, Impersonate-Group/Uid/Extra values would be forwarded to the managed
+// cluster apiserver. On the hub-user path the proxy SA has broad impersonate rights on
+// users/groups, so a client could escalate by injecting Impersonate-Group (e.g.
+// system:masters) which Header.Add would keep alongside the authenticated user's groups.
+// Headers must be cleared for every auth path (including managed-cluster tokens), not only
+// inside processHubUser.
+func stripClientImpersonationHeaders(h http.Header) {
+	h.Del(authenticationv1.ImpersonateUserHeader)
+	h.Del(authenticationv1.ImpersonateGroupHeader)
+	h.Del(authenticationv1.ImpersonateUIDHeader)
+	for key := range h {
+		if strings.HasPrefix(key, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
+			h.Del(key)
+		}
+	}
+}
+
 // processAuthentication handles the authentication flow for both managed cluster and hub users.
 // It tries managed cluster TokenReview first; if unauthenticated, falls back to hub TokenReview.
 func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Request) error {
@@ -362,6 +381,10 @@ func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Requ
 		"tokenPresent", token != "",
 		"tokenLength", len(token),
 	)
+
+	// Always drop client-provided impersonation headers before any auth path forwards the
+	// request. processHubUser will re-apply Impersonate-User/Group from the TokenReview result.
+	stripClientImpersonationHeaders(req.Header)
 
 	// try managed cluster authentication first
 	managedClusterResp, managedClusterAuthenticated, err := s.managedClusterAuthenticator.AuthenticateToken(ctx, token)
@@ -420,22 +443,23 @@ func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Requ
 func (s *serviceProxy) processHubUser(ctx context.Context, req *http.Request, hubUser user.Info) error {
 	logger := klog.FromContext(ctx)
 
-	// set impersonate group header
+	// Ensure no leftover client Impersonate-Group values before adding authenticated groups.
+	req.Header.Del(authenticationv1.ImpersonateGroupHeader)
 	for _, group := range hubUser.GetGroups() {
-		// Here using `Add` instead of `Set` to support multiple groups
-		req.Header.Add("Impersonate-Group", group)
+		// Add (not Set) so multiple groups are preserved after the Del above.
+		req.Header.Add(authenticationv1.ImpersonateGroupHeader, group)
 	}
 
 	// check if the hub user is serviceaccount kind, if so, add "cluster:hub:" prefix to the username
 	username := hubUser.GetName()
 	if strings.HasPrefix(username, "system:serviceaccount:") {
-		req.Header.Set("Impersonate-User", fmt.Sprintf("cluster:hub:%s", username))
+		req.Header.Set(authenticationv1.ImpersonateUserHeader, fmt.Sprintf("cluster:hub:%s", username))
 	} else {
-		req.Header.Set("Impersonate-User", username)
+		req.Header.Set(authenticationv1.ImpersonateUserHeader, username)
 	}
 
 	logger.V(4).Info("impersonation headers set for hub user",
-		"impersonateUser", req.Header.Get("Impersonate-User"),
+		"impersonateUser", req.Header.Get(authenticationv1.ImpersonateUserHeader),
 		"impersonateGroups", hubUser.GetGroups(),
 		"isServiceAccount", strings.HasPrefix(username, "system:serviceaccount:"),
 	)

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -86,15 +86,17 @@ func TestProcessAuthentication_ManagedClusterToken(t *testing.T) {
 	ctx := t.Context()
 	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer mc-token")
+	// Client-supplied impersonation must be stripped even when processHubUser is not called.
+	req.Header.Set(authenticationv1.ImpersonateUserHeader, "system:admin")
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "system:masters")
+	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "escalated-uid")
+	req.Header.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"scopes.authorization.openshift.io", "user:full")
 
 	if err := s.processAuthentication(ctx, req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// For managed cluster tokens, no impersonation headers should be set
-	if req.Header.Get("Impersonate-User") != "" {
-		t.Fatal("impersonation headers should not be set for managed cluster token")
-	}
+	assertNoImpersonationHeaders(t, req.Header)
 }
 
 func TestProcessAuthentication_HubServiceAccountToken(t *testing.T) {
@@ -485,5 +487,125 @@ func TestProcessAuthentication_HubAuthError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "hub apiserver timeout") {
 		t.Fatalf("expected original error message preserved, got: %v", err)
+	}
+}
+
+func TestProcessAuthentication_StripsClientImpersonationOnHubPath(t *testing.T) {
+	s := &serviceProxy{
+		enableImpersonation: true,
+		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+			return nil, false, nil
+		}),
+		hubAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+			return &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name:   "lowpriv",
+					Groups: []string{"system:authenticated"},
+				},
+			}, true, nil
+		}),
+		getImpersonateTokenFunc: func() (string, error) {
+			return "fake-sa-token", nil
+		},
+	}
+
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
+	req.Header.Set("Authorization", "Bearer hub-token")
+	req.Header.Set(authenticationv1.ImpersonateUserHeader, "system:admin")
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "system:masters")
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "cluster-admins")
+	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "escalated-uid")
+	req.Header.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"scopes.authorization.openshift.io", "user:full")
+
+	if err := s.processAuthentication(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := req.Header.Get(authenticationv1.ImpersonateUserHeader); got != "lowpriv" {
+		t.Fatalf("expected Impersonate-User from TokenReview 'lowpriv', got %q", got)
+	}
+
+	groups := req.Header.Values(authenticationv1.ImpersonateGroupHeader)
+	if len(groups) != 1 || groups[0] != "system:authenticated" {
+		t.Fatalf("expected only authenticated group, got %v", groups)
+	}
+	for _, g := range groups {
+		if g == "system:masters" || g == "cluster-admins" {
+			t.Fatalf("client-injected group %q must not be forwarded", g)
+		}
+	}
+
+	if got := req.Header.Get(authenticationv1.ImpersonateUIDHeader); got != "" {
+		t.Fatalf("expected Impersonate-Uid stripped, got %q", got)
+	}
+	if got := req.Header.Get(authenticationv1.ImpersonateUserExtraHeaderPrefix + "scopes.authorization.openshift.io"); got != "" {
+		t.Fatalf("expected Impersonate-Extra stripped, got %q", got)
+	}
+	if req.Header.Get("Authorization") != "Bearer fake-sa-token" {
+		t.Fatalf("expected authorization header to use impersonation token, got %q", req.Header.Get("Authorization"))
+	}
+}
+
+func TestProcessHubUser_IgnoresClientInjectedGroups(t *testing.T) {
+	s := &serviceProxy{
+		getImpersonateTokenFunc: func() (string, error) {
+			return "fake-sa-token", nil
+		},
+	}
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "system:masters")
+
+	hubUser := &user.DefaultInfo{
+		Name:   "admin@example.com",
+		Groups: []string{"system:authenticated"},
+	}
+	if err := s.processHubUser(ctx, req, hubUser); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	groups := req.Header.Values(authenticationv1.ImpersonateGroupHeader)
+	if len(groups) != 1 || groups[0] != "system:authenticated" {
+		t.Fatalf("expected only authenticated group after processHubUser, got %v", groups)
+	}
+}
+
+func TestStripClientImpersonationHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set(authenticationv1.ImpersonateUserHeader, "u")
+	h.Add(authenticationv1.ImpersonateGroupHeader, "g1")
+	h.Add(authenticationv1.ImpersonateGroupHeader, "g2")
+	h.Set(authenticationv1.ImpersonateUIDHeader, "uid")
+	h.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"foo", "bar")
+	h.Set("Authorization", "Bearer keep-me")
+	h.Set("X-Custom", "keep-me-too")
+
+	stripClientImpersonationHeaders(h)
+
+	assertNoImpersonationHeaders(t, h)
+	if h.Get("Authorization") != "Bearer keep-me" {
+		t.Fatalf("Authorization should be preserved, got %q", h.Get("Authorization"))
+	}
+	if h.Get("X-Custom") != "keep-me-too" {
+		t.Fatalf("unrelated headers should be preserved, got %q", h.Get("X-Custom"))
+	}
+}
+
+func assertNoImpersonationHeaders(t *testing.T, h http.Header) {
+	t.Helper()
+	if got := h.Get(authenticationv1.ImpersonateUserHeader); got != "" {
+		t.Fatalf("expected Impersonate-User empty, got %q", got)
+	}
+	if got := h.Values(authenticationv1.ImpersonateGroupHeader); len(got) != 0 {
+		t.Fatalf("expected Impersonate-Group empty, got %v", got)
+	}
+	if got := h.Get(authenticationv1.ImpersonateUIDHeader); got != "" {
+		t.Fatalf("expected Impersonate-Uid empty, got %q", got)
+	}
+	for key, values := range h {
+		if strings.HasPrefix(key, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
+			t.Fatalf("expected Impersonate-Extra headers stripped, found %s=%v", key, values)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Strip client-supplied `Impersonate-*` headers at the start of `processAuthentication`.
- Re-apply hub-user impersonation headers only from TokenReview results.

## Test plan
- [x] `go test ./pkg/serviceproxy/`
- [x] Manual verification on hub/spoke with a low-privileged hub user