### PR TITLE
:sparkles: authorize client impersonation with managed cluster RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ to avoid transferring data-intensive traffic over the proxy when possible.
 
 - Design: [https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/14-addon-cluster-proxy](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/14-addon-cluster-proxy)
 - Addon-Framework: [https://github.com/open-cluster-management-io/addon-framework](https://github.com/open-cluster-management-io/addon-framework)
+- Service-proxy impersonation: [pkg/serviceproxy/readme.md](./pkg/serviceproxy/readme.md)

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -50,13 +50,11 @@ flowchart TD
     B -->|Invalid target| C[Return 400 Bad Request]
     B --> D{Target is kubernetes.default.svc?}
     D -->|No| P[Forward request]
-    D -->|Yes| E{Impersonation enabled?}
-    E -->|No| P
-    E -->|Yes| F{Has client Impersonate-* headers?}
-    F -->|Yes| Q[Keep original token and headers]
+    D -->|Yes| E{Proxy authentication required?<br/>enableImpersonation AND no client Impersonate-*}
+    E -->|No| Q[Skip proxy authentication<br/>and identity rewriting]
     Q --> P
-    Q -.-> R[Managed API server authenticates token<br/>and authorizes impersonation]
-    F -->|No| G{Managed TokenReview succeeds?}
+    Q -.-> R[If Impersonate-* is present, the managed API server<br/>authenticates the token and authorizes impersonation]
+    E -->|Yes| G{Managed TokenReview succeeds?}
     G -->|Yes| P
     G -->|No| H{Hub TokenReview succeeds?}
     H -->|Yes| I[Set hub user and group impersonation]

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -13,10 +13,11 @@ For Kubernetes API requests, service-proxy tries authentication in this order:
 2. Hub cluster TokenReview
 3. External OIDC ID token verification, when configured
 
-The three paths have different forwarding behavior:
+The forwarding behavior is:
 
 | Authentication path | Forwarded identity |
 | --- | --- |
+| Client-supplied `Impersonate-*` headers | The original bearer token and impersonation headers are forwarded unchanged. |
 | Managed cluster TokenReview | The original bearer token is forwarded unchanged. |
 | Hub cluster TokenReview | The request uses the service-proxy service account token and impersonates the hub username and groups. |
 | External OIDC | The request uses the service-proxy service account token and impersonates the mapped OIDC username and groups. |
@@ -51,18 +52,22 @@ flowchart TD
     D -->|No| P[Forward request]
     D -->|Yes| E{Impersonation enabled?}
     E -->|No| P
-    E -->|Yes| F{Managed TokenReview succeeds?}
-    F -->|Yes| P
-    F -->|No| G{Hub TokenReview succeeds?}
-    G -->|Yes| H[Set hub user and group impersonation]
-    G -->|No| I{OIDC configured?}
-    I -->|No| U[Return 401 Unauthorized]
-    I -->|Yes| J{OIDC token valid?}
-    J -->|No| U
-    J -->|Yes| K[Map OIDC claims to user and groups]
-    H --> L[Replace bearer token with proxy ServiceAccount token]
-    K --> L
-    L --> P
+    E -->|Yes| F{Has client Impersonate-* headers?}
+    F -->|Yes| Q[Keep original token and headers]
+    Q --> P
+    Q -.-> R[Managed API server authenticates token<br/>and authorizes impersonation]
+    F -->|No| G{Managed TokenReview succeeds?}
+    G -->|Yes| P
+    G -->|No| H{Hub TokenReview succeeds?}
+    H -->|Yes| I[Set hub user and group impersonation]
+    H -->|No| J{OIDC configured?}
+    J -->|No| U[Return 401 Unauthorized]
+    J -->|Yes| K{OIDC token valid?}
+    K -->|No| U
+    K -->|Yes| L[Map OIDC claims to user and groups]
+    I --> M[Replace bearer token with proxy ServiceAccount token]
+    L --> M
+    M --> P
 ```
 
 ## Enable service-proxy

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -333,12 +333,19 @@ func (s *serviceProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	)
 
 	if url.Host == utils.KubeAPIServerHost {
-		if s.enableImpersonation {
+		clientImpersonationRequested := hasClientImpersonationHeaders(req.Header)
+		// Delegate client impersonation unchanged to the target API server, which authenticates
+		// the original token and authorizes the requested impersonation through its own RBAC.
+		if s.enableImpersonation && !clientImpersonationRequested {
 			if err := s.processAuthentication(ctx, req); err != nil {
 				logger.Error(err, "authentication failed")
 				http.Error(wr, err.Error(), http.StatusUnauthorized)
 				return
 			}
+		} else {
+			logger.V(4).Info("skipping proxy-side authentication",
+				"clientImpersonationRequested", clientImpersonationRequested,
+			)
 		}
 	}
 
@@ -424,19 +431,10 @@ func hasClientImpersonationHeaders(headers http.Header) bool {
 }
 
 // processAuthentication handles the authentication flow for both managed cluster and hub users.
-// Requests that already carry client impersonation headers are forwarded untouched so that the
-// managed cluster apiserver authenticates the caller and authorizes the impersonation itself.
-// Otherwise it tries managed cluster TokenReview first; if unauthenticated, falls back to hub
-// TokenReview, and finally to the configured OIDC issuer.
+// It tries managed cluster TokenReview first; if unauthenticated, falls back to hub TokenReview,
+// and finally to the configured OIDC issuer.
 func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Request) error {
 	logger := klog.FromContext(ctx)
-
-	// Keep this guard before all proxy-side authentication so the original token and
-	// impersonation headers are delegated unchanged to the managed API server.
-	if hasClientImpersonationHeaders(req.Header) {
-		logger.V(4).Info("client impersonation requested, delegating authentication to the managed cluster API server")
-		return nil
-	}
 
 	token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
 

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -407,39 +407,43 @@ func (s *serviceProxy) readImpersonateTokenFromFile() (string, error) {
 	return string(token), nil
 }
 
-// stripClientImpersonationHeaders removes any client-supplied impersonation headers.
-// Without this, Impersonate-Group/Uid/Extra values would be forwarded to the managed
-// cluster apiserver. On the hub-user path the proxy SA has broad impersonate rights on
-// users/groups, so a client could escalate by injecting Impersonate-Group (e.g.
-// system:masters) which Header.Add would keep alongside the authenticated user's groups.
-// Headers must be cleared for every auth path (including managed-cluster tokens), not only
-// inside processHubUser.
-func stripClientImpersonationHeaders(h http.Header) {
-	h.Del(authenticationv1.ImpersonateUserHeader)
-	h.Del(authenticationv1.ImpersonateGroupHeader)
-	h.Del(authenticationv1.ImpersonateUIDHeader)
-	for key := range h {
-		if strings.HasPrefix(key, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
-			h.Del(key)
+// impersonateHeaderPrefix is the common prefix of the impersonation headers declared by
+// authenticationv1: Impersonate-User, Impersonate-Group, Impersonate-Uid and Impersonate-Extra-<key>.
+const impersonateHeaderPrefix = "Impersonate-"
+
+// hasClientImpersonationHeaders reports whether the request contains a Kubernetes impersonation
+// header. Matching the complete prefix case-insensitively also covers future impersonation headers.
+func hasClientImpersonationHeaders(headers http.Header) bool {
+	for key := range headers {
+		if len(key) >= len(impersonateHeaderPrefix) &&
+			strings.EqualFold(key[:len(impersonateHeaderPrefix)], impersonateHeaderPrefix) {
+			return true
 		}
 	}
+	return false
 }
 
 // processAuthentication handles the authentication flow for both managed cluster and hub users.
-// It tries managed cluster TokenReview first; if unauthenticated, falls back to hub TokenReview,
-// and finally to the configured OIDC issuer.
+// Requests that already carry client impersonation headers are forwarded untouched so that the
+// managed cluster apiserver authenticates the caller and authorizes the impersonation itself.
+// Otherwise it tries managed cluster TokenReview first; if unauthenticated, falls back to hub
+// TokenReview, and finally to the configured OIDC issuer.
 func (s *serviceProxy) processAuthentication(ctx context.Context, req *http.Request) error {
 	logger := klog.FromContext(ctx)
+
+	// Keep this guard before all proxy-side authentication so the original token and
+	// impersonation headers are delegated unchanged to the managed API server.
+	if hasClientImpersonationHeaders(req.Header) {
+		logger.V(4).Info("client impersonation requested, delegating authentication to the managed cluster API server")
+		return nil
+	}
+
 	token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
 
 	logger.V(6).Info("processing authentication for request",
 		"tokenPresent", token != "",
 		"tokenLength", len(token),
 	)
-
-	// Always drop client-provided impersonation headers before any auth path forwards the
-	// request. processHubUser will re-apply Impersonate-User/Group from the TokenReview result.
-	stripClientImpersonationHeaders(req.Header)
 
 	// try managed cluster authentication first
 	managedClusterResp, managedClusterAuthenticated, err := s.managedClusterAuthenticator.AuthenticateToken(ctx, token)

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
-	"reflect"
+	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -16,6 +18,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	"open-cluster-management.io/cluster-proxy/pkg/utils"
 )
 
 // newFakeClient creates a fake kubernetes client that responds to TokenReview
@@ -166,41 +170,125 @@ func TestHasClientImpersonationHeaders(t *testing.T) {
 	}
 }
 
-func TestProcessAuthentication_ForwardsClientImpersonationUnchanged(t *testing.T) {
-	failAuthentication := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-		t.Fatal("proxy authentication must not run for client impersonation")
-		return nil, false, nil
-	})
-	s := &serviceProxy{
-		enableImpersonation:         true,
-		managedClusterAuthenticator: failAuthentication,
-		hubAuthenticator:            failAuthentication,
-		oidcAuthenticator:           failAuthentication,
-		getImpersonateTokenFunc: func() (string, error) {
-			t.Fatal("proxy service account token must not be read for client impersonation")
-			return "", nil
+type requestCapturingRoundTripper struct {
+	request *http.Request
+}
+
+func (t *requestCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req.Clone(req.Context())
+	t.request.Header = req.Header.Clone()
+
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        "200 OK",
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader("ok")),
+		ContentLength: 2,
+		Request:       req,
+	}, nil
+}
+
+func (t *requestCapturingRoundTripper) CloseIdleConnections() {}
+
+func TestServeHTTPAuthenticationRouting(t *testing.T) {
+	tests := []struct {
+		name                       string
+		enableImpersonation        bool
+		clientImpersonationHeaders bool
+		wantAuthenticationCalls    int
+	}{
+		{
+			name:                    "disabled without client impersonation headers",
+			enableImpersonation:     false,
+			wantAuthenticationCalls: 0,
+		},
+		{
+			name:                       "disabled with client impersonation headers",
+			enableImpersonation:        false,
+			clientImpersonationHeaders: true,
+			wantAuthenticationCalls:    0,
+		},
+		{
+			name:                       "enabled with client impersonation headers",
+			enableImpersonation:        true,
+			clientImpersonationHeaders: true,
+			wantAuthenticationCalls:    0,
+		},
+		{
+			name:                    "enabled without client impersonation headers",
+			enableImpersonation:     true,
+			wantAuthenticationCalls: 1,
 		},
 	}
 
-	ctx := t.Context()
-	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
-	req.Header.Set("Authorization", "Bearer original-token")
-	req.Header.Set(authenticationv1.ImpersonateUserHeader, "alice")
-	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "developers")
-	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "auditors")
-	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "alice-uid")
-	req.Header.Add("Impersonate-Extra-example.org%2Fscope", "read")
-	req.Header.Add("Impersonate-Extra-example.org%2Fscope", "write")
-	req.Header.Add("X-Unrelated", "first")
-	req.Header.Add("X-Unrelated", "second")
-	originalHeaders := req.Header.Clone()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authenticationCalls := 0
+			transport := &requestCapturingRoundTripper{}
+			s := &serviceProxy{
+				enableImpersonation: tt.enableImpersonation,
+				managedClusterAuthenticator: authenticator.TokenFunc(
+					func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+						authenticationCalls++
+						return &authenticator.Response{User: &user.DefaultInfo{Name: "managed-user"}}, true, nil
+					},
+				),
+				hubAuthenticator: authenticator.TokenFunc(
+					func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+						t.Fatal("hub authenticator should not be called")
+						return nil, false, nil
+					},
+				),
+				oidcAuthenticator: authenticator.TokenFunc(
+					func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+						t.Fatal("OIDC authenticator should not be called")
+						return nil, false, nil
+					},
+				),
+				getImpersonateTokenFunc: func() (string, error) {
+					t.Fatal("proxy service account token should not be read")
+					return "", nil
+				},
+				proxyTransport: transport,
+			}
 
-	if err := s.processAuthentication(ctx, req); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+			req := httptest.NewRequest(http.MethodGet, "https://service-proxy.example/api/v1/pods", nil)
+			req.Header.Set("Authorization", "Bearer original-token")
+			req.Header.Add("X-Unrelated", "first")
+			req.Header.Add("X-Unrelated", "second")
+			if tt.clientImpersonationHeaders {
+				req.Header.Set(authenticationv1.ImpersonateUserHeader, "alice")
+				req.Header.Add(authenticationv1.ImpersonateGroupHeader, "developers")
+				req.Header.Add(authenticationv1.ImpersonateGroupHeader, "auditors")
+				req.Header.Set(authenticationv1.ImpersonateUIDHeader, "alice-uid")
+				req.Header.Add("Impersonate-Extra-example.org%2Fscope", "read")
+				req.Header.Add("Impersonate-Extra-example.org%2Fscope", "write")
+				req.Header.Set("Impersonate-Future", "future-value")
+			}
+			req.Header.Set(utils.HeaderClusterProxyProto, "https")
+			req.Header.Set(utils.HeaderClusterProxyNamespace, "default")
+			req.Header.Set(utils.HeaderClusterProxyService, "kubernetes")
+			req.Header.Set(utils.HeaderClusterProxyPort, "443")
+			originalHeaders := req.Header.Clone()
+			recorder := httptest.NewRecorder()
 
-	if !reflect.DeepEqual(req.Header, originalHeaders) {
-		t.Fatalf("request headers changed: got %#v, want %#v", req.Header, originalHeaders)
+			s.ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("unexpected status: got %d, want 200: %s", recorder.Code, recorder.Body.String())
+			}
+			if authenticationCalls != tt.wantAuthenticationCalls {
+				t.Fatalf("authentication called %d times, want %d", authenticationCalls, tt.wantAuthenticationCalls)
+			}
+			if transport.request == nil {
+				t.Fatal("request was not forwarded")
+			}
+			for key, want := range originalHeaders {
+				if got := transport.request.Header.Values(key); !slices.Equal(got, want) {
+					t.Errorf("forwarded %s header values = %q, want %q", key, got, want)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/serviceproxy/token_authenticator_test.go
+++ b/pkg/serviceproxy/token_authenticator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -86,17 +87,121 @@ func TestProcessAuthentication_ManagedClusterToken(t *testing.T) {
 	ctx := t.Context()
 	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
 	req.Header.Set("Authorization", "Bearer mc-token")
-	// Client-supplied impersonation must be stripped even when processHubUser is not called.
-	req.Header.Set(authenticationv1.ImpersonateUserHeader, "system:admin")
-	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "system:masters")
-	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "escalated-uid")
-	req.Header.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"scopes.authorization.openshift.io", "user:full")
 
 	if err := s.processAuthentication(ctx, req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertNoImpersonationHeaders(t, req.Header)
+	if got := req.Header.Get("Authorization"); got != "Bearer mc-token" {
+		t.Fatalf("expected original authorization header, got %q", got)
+	}
+	if req.Header.Get(authenticationv1.ImpersonateUserHeader) != "" {
+		t.Fatal("impersonation headers should not be set for managed cluster token")
+	}
+}
+
+func TestHasClientImpersonationHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  http.Header
+		expected bool
+	}{
+		{
+			name: "none",
+			headers: http.Header{
+				"Authorization": {"Bearer token"},
+			},
+			expected: false,
+		},
+		{
+			name: "lowercase user",
+			headers: http.Header{
+				"impersonate-user": {"alice"},
+			},
+			expected: true,
+		},
+		{
+			name: "uppercase group",
+			headers: http.Header{
+				"IMPERSONATE-GROUP": {"developers"},
+			},
+			expected: true,
+		},
+		{
+			name: "mixed-case UID",
+			headers: http.Header{
+				"ImPeRsOnAtE-Uid": {"uid"},
+			},
+			expected: true,
+		},
+		{
+			name: "lowercase extra",
+			headers: http.Header{
+				"impersonate-extra-example.org%2Fscope": {"read"},
+			},
+			expected: true,
+		},
+		{
+			name: "unknown empty impersonation header",
+			headers: http.Header{
+				"Impersonate-Future": {""},
+			},
+			expected: true,
+		},
+		{
+			name: "similar header",
+			headers: http.Header{
+				"X-Impersonate-User": {"alice"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasClientImpersonationHeaders(tt.headers); got != tt.expected {
+				t.Fatalf("expected %t, got %t", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestProcessAuthentication_ForwardsClientImpersonationUnchanged(t *testing.T) {
+	failAuthentication := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+		t.Fatal("proxy authentication must not run for client impersonation")
+		return nil, false, nil
+	})
+	s := &serviceProxy{
+		enableImpersonation:         true,
+		managedClusterAuthenticator: failAuthentication,
+		hubAuthenticator:            failAuthentication,
+		oidcAuthenticator:           failAuthentication,
+		getImpersonateTokenFunc: func() (string, error) {
+			t.Fatal("proxy service account token must not be read for client impersonation")
+			return "", nil
+		},
+	}
+
+	ctx := t.Context()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
+	req.Header.Set("Authorization", "Bearer original-token")
+	req.Header.Set(authenticationv1.ImpersonateUserHeader, "alice")
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "developers")
+	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "auditors")
+	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "alice-uid")
+	req.Header.Add("Impersonate-Extra-example.org%2Fscope", "read")
+	req.Header.Add("Impersonate-Extra-example.org%2Fscope", "write")
+	req.Header.Add("X-Unrelated", "first")
+	req.Header.Add("X-Unrelated", "second")
+	originalHeaders := req.Header.Clone()
+
+	if err := s.processAuthentication(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(req.Header, originalHeaders) {
+		t.Fatalf("request headers changed: got %#v, want %#v", req.Header, originalHeaders)
+	}
 }
 
 func TestProcessAuthentication_HubServiceAccountToken(t *testing.T) {
@@ -490,63 +595,6 @@ func TestProcessAuthentication_HubAuthError(t *testing.T) {
 	}
 }
 
-func TestProcessAuthentication_StripsClientImpersonationOnHubPath(t *testing.T) {
-	s := &serviceProxy{
-		enableImpersonation: true,
-		managedClusterAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			return nil, false, nil
-		}),
-		hubAuthenticator: authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-			return &authenticator.Response{
-				User: &user.DefaultInfo{
-					Name:   "lowpriv",
-					Groups: []string{"system:authenticated"},
-				},
-			}, true, nil
-		}),
-		getImpersonateTokenFunc: func() (string, error) {
-			return "fake-sa-token", nil
-		},
-	}
-
-	ctx := t.Context()
-	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/api", nil)
-	req.Header.Set("Authorization", "Bearer hub-token")
-	req.Header.Set(authenticationv1.ImpersonateUserHeader, "system:admin")
-	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "system:masters")
-	req.Header.Add(authenticationv1.ImpersonateGroupHeader, "cluster-admins")
-	req.Header.Set(authenticationv1.ImpersonateUIDHeader, "escalated-uid")
-	req.Header.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"scopes.authorization.openshift.io", "user:full")
-
-	if err := s.processAuthentication(ctx, req); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if got := req.Header.Get(authenticationv1.ImpersonateUserHeader); got != "lowpriv" {
-		t.Fatalf("expected Impersonate-User from TokenReview 'lowpriv', got %q", got)
-	}
-
-	groups := req.Header.Values(authenticationv1.ImpersonateGroupHeader)
-	if len(groups) != 1 || groups[0] != "system:authenticated" {
-		t.Fatalf("expected only authenticated group, got %v", groups)
-	}
-	for _, g := range groups {
-		if g == "system:masters" || g == "cluster-admins" {
-			t.Fatalf("client-injected group %q must not be forwarded", g)
-		}
-	}
-
-	if got := req.Header.Get(authenticationv1.ImpersonateUIDHeader); got != "" {
-		t.Fatalf("expected Impersonate-Uid stripped, got %q", got)
-	}
-	if got := req.Header.Get(authenticationv1.ImpersonateUserExtraHeaderPrefix + "scopes.authorization.openshift.io"); got != "" {
-		t.Fatalf("expected Impersonate-Extra stripped, got %q", got)
-	}
-	if req.Header.Get("Authorization") != "Bearer fake-sa-token" {
-		t.Fatalf("expected authorization header to use impersonation token, got %q", req.Header.Get("Authorization"))
-	}
-}
-
 func TestProcessHubUser_IgnoresClientInjectedGroups(t *testing.T) {
 	s := &serviceProxy{
 		getImpersonateTokenFunc: func() (string, error) {
@@ -568,44 +616,5 @@ func TestProcessHubUser_IgnoresClientInjectedGroups(t *testing.T) {
 	groups := req.Header.Values(authenticationv1.ImpersonateGroupHeader)
 	if len(groups) != 1 || groups[0] != "system:authenticated" {
 		t.Fatalf("expected only authenticated group after processHubUser, got %v", groups)
-	}
-}
-
-func TestStripClientImpersonationHeaders(t *testing.T) {
-	h := http.Header{}
-	h.Set(authenticationv1.ImpersonateUserHeader, "u")
-	h.Add(authenticationv1.ImpersonateGroupHeader, "g1")
-	h.Add(authenticationv1.ImpersonateGroupHeader, "g2")
-	h.Set(authenticationv1.ImpersonateUIDHeader, "uid")
-	h.Set(authenticationv1.ImpersonateUserExtraHeaderPrefix+"foo", "bar")
-	h.Set("Authorization", "Bearer keep-me")
-	h.Set("X-Custom", "keep-me-too")
-
-	stripClientImpersonationHeaders(h)
-
-	assertNoImpersonationHeaders(t, h)
-	if h.Get("Authorization") != "Bearer keep-me" {
-		t.Fatalf("Authorization should be preserved, got %q", h.Get("Authorization"))
-	}
-	if h.Get("X-Custom") != "keep-me-too" {
-		t.Fatalf("unrelated headers should be preserved, got %q", h.Get("X-Custom"))
-	}
-}
-
-func assertNoImpersonationHeaders(t *testing.T, h http.Header) {
-	t.Helper()
-	if got := h.Get(authenticationv1.ImpersonateUserHeader); got != "" {
-		t.Fatalf("expected Impersonate-User empty, got %q", got)
-	}
-	if got := h.Values(authenticationv1.ImpersonateGroupHeader); len(got) != 0 {
-		t.Fatalf("expected Impersonate-Group empty, got %v", got)
-	}
-	if got := h.Get(authenticationv1.ImpersonateUIDHeader); got != "" {
-		t.Fatalf("expected Impersonate-Uid empty, got %q", got)
-	}
-	for key, values := range h {
-		if strings.HasPrefix(key, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
-			t.Fatalf("expected Impersonate-Extra headers stripped, found %s=%v", key, values)
-		}
 	}
 }

--- a/test/e2e/connect_test.go
+++ b/test/e2e/connect_test.go
@@ -16,7 +16,9 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -165,6 +167,72 @@ var _ = Describe("Requests through Cluster-Proxy", Label("serviceproxy", "connec
 		})
 	})
 
+	Describe("Impersonate a user", Label("impersonation"), func() {
+		It("should delegate authentication and authorization to the managed kube-apiserver", Label("impersonate-user"), func() {
+			targetUser := "cluster-proxy-e2e-impersonated-user"
+			deniedUser := "cluster-proxy-e2e-denied-user"
+
+			impersonateRole, err := hubKubeClient.RbacV1().ClusterRoles().Create(context.Background(), &rbacv1.ClusterRole{
+				ObjectMeta: v1.ObjectMeta{GenerateName: "cluster-proxy-e2e-impersonate-"},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Resources:     []string{"users"},
+						ResourceNames: []string{targetUser},
+						Verbs:         []string{"impersonate"},
+					},
+				},
+			}, v1.CreateOptions{})
+			Expect(err).To(BeNil())
+			DeferCleanup(func() {
+				err := hubKubeClient.RbacV1().ClusterRoles().Delete(context.Background(), impersonateRole.Name, v1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+
+			impersonateBinding, err := hubKubeClient.RbacV1().ClusterRoleBindings().Create(context.Background(), &rbacv1.ClusterRoleBinding{
+				ObjectMeta: v1.ObjectMeta{GenerateName: "cluster-proxy-e2e-impersonate-"},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     impersonateRole.Name,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      serviceAccountName,
+						Namespace: hubInstallNamespace,
+					},
+				},
+			}, v1.CreateOptions{})
+			Expect(err).To(BeNil())
+			DeferCleanup(func() {
+				err := hubKubeClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), impersonateBinding.Name, v1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+
+			// SelfSubjectReview reports the identity the managed kube-apiserver ended up with, and
+			// every authenticated user may create one, so no extra RBAC is needed on the impersonated
+			// users and the denied request below can only fail on the impersonation check.
+			authorizedClient := impersonatingClusterProxyClient(targetUser)
+			Eventually(func() error {
+				review, err := authorizedClient.AuthenticationV1().SelfSubjectReviews().Create(
+					context.Background(), &authenticationv1.SelfSubjectReview{}, v1.CreateOptions{})
+				if err != nil {
+					return err
+				}
+				if review.Status.UserInfo.Username != targetUser {
+					return fmt.Errorf("expected impersonated user %s, got %s", targetUser, review.Status.UserInfo.Username)
+				}
+				return nil
+			}, timeout, time.Second).Should(Succeed())
+
+			_, err = impersonatingClusterProxyClient(deniedUser).AuthenticationV1().SelfSubjectReviews().Create(
+				context.Background(), &authenticationv1.SelfSubjectReview{}, v1.CreateOptions{})
+			Expect(err).ToNot(BeNil())
+			Expect(errors.IsForbidden(err)).To(Equal(true))
+		})
+	})
+
 	Describe("Get Logs of a pod", Label("logs"), func() {
 		It("should return logs information", Label("pod-logs"), func() {
 			req := clusterProxyKubeClient.CoreV1().Pods(hubInstallNamespace).GetLogs(podName, &corev1.PodLogOptions{})
@@ -298,6 +366,16 @@ var _ = Describe("Requests through Cluster-Proxy", Label("serviceproxy", "connec
 		})
 	})
 })
+
+// impersonatingClusterProxyClient returns a cluster-proxy client that asks the managed cluster
+// apiserver to impersonate the given user.
+func impersonatingClusterProxyClient(userName string) kubernetes.Interface {
+	cfg := rest.CopyConfig(clusterProxyCfg)
+	cfg.Impersonate = rest.ImpersonationConfig{UserName: userName}
+	client, err := kubernetes.NewForConfig(cfg)
+	Expect(err).To(BeNil())
+	return client
+}
 
 func waitForClusterProxyKubeAPIAvailable() {
 	Eventually(func() error {


### PR DESCRIPTION
## Background

The Cluster Inventory API is expected to enable a wider range of controllers running on the hub cluster to access managed cluster Kubernetes APIs. To support this direction, cluster-proxy should preserve native Kubernetes API behavior wherever possible and avoid introducing OCM-specific limitations.

Kubernetes impersonation is one example. A client can use `kubectl --as` or `kubectl --as-group` when accessing a managed cluster API server directly, provided that the managed cluster's RBAC permits the caller to impersonate the requested identity. Previously, cluster-proxy stripped client-supplied `Impersonate-*` headers. As a result, the same request behaved differently depending on whether it was sent directly to the API server or through cluster-proxy.

This difference can become a subtle trap for users and prevents cluster-proxy from acting as a transparent transport for the Kubernetes API. This change is not part of the OIDC work and is not motivated by an OIDC-specific use case.

## Goal

The goal of this PR is to support native Kubernetes client impersonation through service-proxy while preserving the same authentication and authorization semantics as direct access to the managed cluster API server.

When a client supplies an `Impersonate-*` header, service-proxy forwards the original `Authorization` and impersonation headers unchanged. The managed cluster API server then authenticates the original token and authorizes the requested impersonation through its own RBAC. This keeps authorization enforcement at the target managed cluster and avoids reimplementing Kubernetes impersonation authorization in cluster-proxy.

Reducing this incompatibility makes cluster-proxy more transparent for existing Kubernetes clients and removes one potential OCM-specific limitation for controllers that may run on the hub cluster in the future.

## Summary

Allow Kubernetes clients to use native impersonation through service-proxy without reimplementing the Kubernetes API server's impersonation authorization.

For requests targeting the managed cluster Kubernetes API:

- If any case-insensitive `Impersonate-*` header is present, service-proxy skips its managed-cluster, hub, and OIDC authentication flow and forwards the original `Authorization` and `Impersonate-*` headers without proxy-side identity rewriting.
- This pass-through is independent of `enableImpersonation`. The managed Kubernetes API server authenticates the original token and authorizes the requested user, group, UID, extra, or future impersonation header through its own RBAC.
- If no client `Impersonate-*` header is present and `enableImpersonation=true`, the existing managed TokenReview -> hub TokenReview -> optional OIDC flow is used.
- The proxy ServiceAccount token and generated impersonation headers are used only for successful hub or OIDC fallback authentication.

This preserves Kubernetes API server compatibility while keeping authorization enforcement at the target managed cluster. The PR also documents the request flow and includes case-insensitive header detection plus allowed/denied end-to-end coverage.

## Testing

- `go test ./pkg/... -count=1`
- Unit coverage for `enableImpersonation` enabled/disabled, with and without client `Impersonate-*` headers
- End-to-end coverage for allowed and denied native client impersonation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transparent handling of client impersonation headers for managed-cluster requests.
  * Added end-to-end coverage validating both authorized and denied impersonated access.
* **Bug Fixes**
  * Preserves the original authorization and impersonation headers for managed-cluster authentication and RBAC evaluation.
* **Documentation**
  * Updated service-proxy documentation and flowchart behavior for impersonation scenarios.
  * Documented and surfaced the `enableImpersonation` Helm setting in chart/readme references.  
* **Tests**
  * Expanded unit and e2e tests to cover impersonation header detection and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
