### PR TITLE
:bug: recognize the kube-apiserver target by Service identity

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -329,10 +329,10 @@ func (s *serviceProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	logger.V(4).Info("service proxy received request",
 		"targetScheme", url.Scheme,
 		"enableImpersonation", s.enableImpersonation,
-		"isKubeAPIServer", url.Host == "kubernetes.default.svc",
+		"isKubeAPIServer", url.Host == utils.KubeAPIServerHost,
 	)
 
-	if url.Host == "kubernetes.default.svc" {
+	if url.Host == utils.KubeAPIServerHost {
 		if s.enableImpersonation {
 			if err := s.processAuthentication(ctx, req); err != nil {
 				logger.Error(err, "authentication failed")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,11 @@ const (
 	HEADERSERVICECERT = "Service-Client-Cert"
 	HEADERSERVICEKEY  = "Service-Client-Key"
 
+	KubeAPIServerHost = "kubernetes.default.svc"
+
+	kubeAPIServerService   = "kubernetes"
+	kubeAPIServerNamespace = "default"
+
 	// Cluster-Proxy custom headers for service proxy
 	HeaderClusterProxyProto     = "Cluster-Proxy-Proto"
 	HeaderClusterProxyNamespace = "Cluster-Proxy-Namespace"
@@ -123,8 +128,8 @@ func GetTargetServiceURLFromRequest(req *http.Request) (*url.URL, error) {
 
 	var targetServiceURL string
 	// check if the request is meant to proxy to kube-apiserver
-	if proto == "https" && service == "kubernetes" && namespace == "default" && port == "443" {
-		targetServiceURL = "https://kubernetes.default.svc"
+	if strings.EqualFold(service, kubeAPIServerService) && strings.EqualFold(namespace, kubeAPIServerNamespace) {
+		targetServiceURL = "https://" + KubeAPIServerHost
 	} else {
 		targetServiceURL = fmt.Sprintf("%s://%s.%s.svc:%s", proto, service, namespace, port)
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -247,6 +247,66 @@ func TestGetTargetServiceURLFromRequest(t *testing.T) {
 			expect: "https://kubernetes.default.svc",
 		},
 		{
+			name: "kubernetes apiserver with a non-canonical port",
+			req: &http.Request{
+				Header: map[string][]string{
+					HeaderClusterProxyProto:     {"https"},
+					HeaderClusterProxyPort:      {"0443"},
+					HeaderClusterProxyService:   {"kubernetes"},
+					HeaderClusterProxyNamespace: {"default"},
+				},
+			},
+			expect: "https://kubernetes.default.svc",
+		},
+		{
+			name: "kubernetes apiserver with a non-canonical scheme",
+			req: &http.Request{
+				Header: map[string][]string{
+					HeaderClusterProxyProto:     {"http"},
+					HeaderClusterProxyPort:      {"80"},
+					HeaderClusterProxyService:   {"kubernetes"},
+					HeaderClusterProxyNamespace: {"default"},
+				},
+			},
+			expect: "https://kubernetes.default.svc",
+		},
+		{
+			name: "kubernetes apiserver with a mixed-case service",
+			req: &http.Request{
+				Header: map[string][]string{
+					HeaderClusterProxyProto:     {"https"},
+					HeaderClusterProxyPort:      {"443"},
+					HeaderClusterProxyService:   {"Kubernetes"},
+					HeaderClusterProxyNamespace: {"default"},
+				},
+			},
+			expect: "https://kubernetes.default.svc",
+		},
+		{
+			name: "kubernetes apiserver with a mixed-case namespace",
+			req: &http.Request{
+				Header: map[string][]string{
+					HeaderClusterProxyProto:     {"https"},
+					HeaderClusterProxyPort:      {"443"},
+					HeaderClusterProxyService:   {"kubernetes"},
+					HeaderClusterProxyNamespace: {"Default"},
+				},
+			},
+			expect: "https://kubernetes.default.svc",
+		},
+		{
+			name: "service named kubernetes in another namespace",
+			req: &http.Request{
+				Header: map[string][]string{
+					HeaderClusterProxyProto:     {"https"},
+					HeaderClusterProxyPort:      {"443"},
+					HeaderClusterProxyService:   {"kubernetes"},
+					HeaderClusterProxyNamespace: {"other"},
+				},
+			},
+			expect: "https://kubernetes.other.svc:443",
+		},
+		{
 			name: "other services",
 			req: &http.Request{
 				Header: map[string][]string{


### PR DESCRIPTION
The service proxy recognized kube-apiserver traffic only when the scheme and port were exactly `https` and `443`. A request such as `https:kubernetes:0443` still reached the API server but followed the regular Service path, skipping authentication and impersonation handling.

Identify the kube-apiserver by the `default/kubernetes` Service and normalize the target URL to `https://kubernetes.default.svc`.
