### PR TITLE
:bug: drain in-flight requests on shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ test-helm: verify-helm-dependencies validate-values-schema verify-shutdown-grace
 verify-shutdown-grace-periods:
 	@$(HELM) template cluster-proxy charts/cluster-proxy \
 		--namespace open-cluster-management-addon \
+		--show-only templates/manager-deployment.yaml | \
+		grep -Eq '^[[:space:]]+terminationGracePeriodSeconds: 40$$'
+	@$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon \
 		--set enableServiceProxy=true \
 		--show-only templates/user-deployment.yaml | \
 		grep -Eq '^[[:space:]]+terminationGracePeriodSeconds: 40$$'

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: manifests generate fmt vet envtest-setup ## Run tests.
 	go test ./pkg/... -coverprofile cover.out
 
 .PHONY: test-helm
-test-helm: verify-helm-dependencies validate-values-schema ## Lint and render Helm charts.
+test-helm: verify-helm-dependencies validate-values-schema verify-shutdown-grace-periods ## Lint and render Helm charts.
 	$(HELM) lint charts/cluster-proxy
 	$(HELM) template cluster-proxy charts/cluster-proxy \
 		--namespace open-cluster-management-addon >/dev/null
@@ -139,6 +139,19 @@ test-helm: verify-helm-dependencies validate-values-schema ## Lint and render He
 	{ ! $(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
 		--namespace open-cluster-management-agent-addon \
 		--set oidcReservedNamePrefixes=null 2>&1; } | grep -q oidcReservedNamePrefixes
+
+.PHONY: verify-shutdown-grace-periods
+verify-shutdown-grace-periods:
+	@$(HELM) template cluster-proxy charts/cluster-proxy \
+		--namespace open-cluster-management-addon \
+		--set enableServiceProxy=true \
+		--show-only templates/user-deployment.yaml | \
+		grep -Eq '^[[:space:]]+terminationGracePeriodSeconds: 40$$'
+	@$(HELM) template addon-agent pkg/proxyagent/agent/manifests/charts/addon-agent \
+		--namespace open-cluster-management-agent-addon \
+		--set enableServiceProxy=true \
+		--show-only templates/addon-agent-deployment.yaml | \
+		grep -Eq '^[[:space:]]+terminationGracePeriodSeconds: 40$$'
 
 ##@ Build
 

--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         component: cluster-proxy-manager
     spec:
       serviceAccount: cluster-proxy
+      # Binaries drain for up to 30s after SIGTERM; the extra 10s lets forced
+      # cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         component: cluster-proxy-addon-user
     spec:
       serviceAccount: cluster-proxy
+      # Binaries drain for up to 30s after SIGTERM; the extra 10s lets forced
+      # cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/cmd/addon-manager/main.go
+++ b/cmd/addon-manager/main.go
@@ -183,8 +183,8 @@ func main() {
 	// So we could alternatively add a watch there on the configmap and simply reconcile.
 	// This way keeps it simpler with common code, but does restart when the configmap changes
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, nativeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
 		setupLog.Error(err, "failed to start TLS ConfigMap watcher")

--- a/cmd/cluster-proxy/main.go
+++ b/cmd/cluster-proxy/main.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
 	goflag "flag"
 	"fmt"
+	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -24,24 +29,40 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	os.Exit(runMain(execute, os.Stderr, logs.FlushLogs))
+}
 
-	command := newClusterProxyCommand()
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+func runMain(executeCommand func() error, stderr io.Writer, flushLogs func()) int {
+	defer flushLogs()
+
+	if err := executeCommand(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
+
+	return 0
+}
+
+func execute() error {
+	ctx, stop := newSignalContext(context.Background())
+	defer stop()
+
+	return newClusterProxyCommand().ExecuteContext(ctx)
+}
+
+func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 }
 
 func newClusterProxyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-proxy",
 		Short: "cluster-proxy",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmd.Help(); err != nil {
-				klog.Errorf("cmd help err: %v", err)
+				return err
 			}
-			os.Exit(1)
+			return errors.New("a subcommand is required")
 		},
 	}
 

--- a/cmd/cluster-proxy/main_test.go
+++ b/cmd/cluster-proxy/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunMain(t *testing.T) {
+	tests := []struct {
+		name         string
+		execute      func() error
+		wantExitCode int
+		wantStderr   string
+		wantFlushes  int
+	}{
+		{
+			name:         "success",
+			execute:      func() error { return nil },
+			wantExitCode: 0,
+			wantFlushes:  1,
+		},
+		{
+			name:         "error",
+			execute:      func() error { return errors.New("boom") },
+			wantExitCode: 1,
+			wantStderr:   "boom\n",
+			wantFlushes:  1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stderr strings.Builder
+			flushes := 0
+
+			exitCode := runMain(test.execute, &stderr, func() {
+				flushes++
+			})
+
+			if exitCode != test.wantExitCode {
+				t.Errorf("exit code = %d, want %d", exitCode, test.wantExitCode)
+			}
+			if stderr.String() != test.wantStderr {
+				t.Errorf("stderr = %q, want %q", stderr.String(), test.wantStderr)
+			}
+			if flushes != test.wantFlushes {
+				t.Errorf("flush count = %d, want %d", flushes, test.wantFlushes)
+			}
+		})
+	}
+}
+
+func TestSignalContextPreservesParentCancellation(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	ctx, stop := newSignalContext(parent)
+	defer stop()
+
+	cancelParent()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("signal context did not propagate parent cancellation")
+	}
+}

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"open-cluster-management.io/cluster-proxy/pkg/proxyserver/operator/authentication/selfsigned"
@@ -45,11 +44,8 @@ func NewControllersCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controllers",
 		Short: "controllers",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := runControllerManager()
-			if err != nil {
-				klog.Fatal(err, "unable to run controller manager")
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runControllerManager(cmd.Context())
 		},
 	}
 
@@ -66,23 +62,26 @@ func addFlags(cmd *cobra.Command) {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 }
 
-func runControllerManager() error {
-	ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
+func runControllerManager(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Setup clients, informers and listers.
-	kubeConfig := config.GetConfigOrDie()
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get Kubernetes config: %w", err)
+	}
 
 	// secret client and lister
 	nativeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("create Kubernetes client: %w", err)
 	}
 	secertClient := nativeClient.CoreV1()
 	informerFactory := informers.NewSharedInformerFactory(nativeClient, 10*time.Minute)
 	secertLister := informerFactory.Core().V1().Secrets().Lister()
 
-	go informerFactory.Start(ctx.Done())
+	go informerFactory.Start(runCtx.Done())
 
 	// New controller manager
 	mgr, err := manager.New(kubeConfig, manager.Options{
@@ -99,20 +98,18 @@ func runControllerManager() error {
 	})
 	if err != nil {
 		klog.Error(err, "unable to set up overall controller manager")
-		return err
+		return fmt.Errorf("set up controller manager: %w", err)
 	}
 
 	// loading ManagedProxyConfiguration for owner reference
 	proxyClient, err := proxyclient.NewForConfig(mgr.GetConfig())
 	if err != nil {
-		klog.Error(err, "unable to set up proxy client")
-		os.Exit(1)
+		return fmt.Errorf("set up proxy client: %w", err)
 	}
 	proxyConfig, err := proxyClient.ProxyV1alpha1().ManagedProxyConfigurations().Get(
-		context.TODO(), "cluster-proxy", metav1.GetOptions{})
+		runCtx, "cluster-proxy", metav1.GetOptions{})
 	if err != nil {
-		klog.Error(err, "failed to get ManagedProxyConfiguration 'cluster-proxy'")
-		os.Exit(1)
+		return fmt.Errorf("get ManagedProxyConfiguration %q: %w", "cluster-proxy", err)
 	}
 	ownerRef := selfsigned.NewOwnerReferenceFromConfig(proxyConfig)
 
@@ -121,12 +118,12 @@ func runControllerManager() error {
 		secertLister, secertClient, ownerRef, mgr)
 	if err != nil {
 		klog.Error(err, "unable to set up cert-controller")
-		return err
+		return fmt.Errorf("set up cert controller: %w", err)
 	}
 
-	if err := mgr.Start(ctx); err != nil {
+	if err := mgr.Start(runCtx); err != nil {
 		klog.Error(err, "problem running manager")
-		return err
+		return fmt.Errorf("run controller manager: %w", err)
 	}
 	return nil
 }

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -1016,6 +1016,7 @@ func assertPodSecurityContext(t *testing.T, deploy *appsv1.Deployment) {
 		},
 	}
 	assert.Equal(t, expected, deploy.Spec.Template.Spec.SecurityContext)
+	assert.Equal(t, ptr.To(int64(40)), deploy.Spec.Template.Spec.TerminationGracePeriodSeconds)
 }
 
 type fakeSelfSigner struct {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - {{ .Values.serviceProxyHost }}
       {{- end }}
       serviceAccount: cluster-proxy
+      # Binaries drain for up to 30s after SIGTERM; the extra 10s lets forced
+      # cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -155,6 +155,9 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	const (
 		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	)
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var err error
 	customChecks := []healthz.Checker{}
 
@@ -262,15 +265,15 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
-		klog.Fatalf("Pod namespace is empty, please set the ENV for POD_NAMESPACE")
+		return errors.New("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
-	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, s.managedClusterKubeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, s.managedClusterKubeClient, podNamespace, func() {
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
-		klog.Fatalf("failed to start TLS ConfigMap watcher: %v", err)
+		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
 	}
 	klog.Infof("TLS config loaded: minVersion=%s, ciphersuites=%s", sdktls.VersionToString(sdkTLSConfig.MinVersion),
 		sdktls.CipherSuitesToString(sdkTLSConfig.CipherSuites))
@@ -280,21 +283,26 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		CipherSuites: sdkTLSConfig.CipherSuites,
 	}
 
-	go func() {
-		// Currently ServeHealthProbes uses HTTP so our tlsConfig is not needed, however passing through for
-		// consistency and in case it's ever updated to use HTTPS in the future
-		if err = utils.ServeHealthProbes(":8000", tlsConfig, customChecks...); err != nil {
-			klog.Fatal(err)
-		}
-	}()
+	healthServer := utils.NewHealthProbeServer(":8000", tlsConfig, customChecks...)
+	publicServer := utils.NewHTTPServer(fmt.Sprintf(":%d", constant.ServiceProxyPort), tlsConfig, s)
 
-	httpserver := &http.Server{
-		Addr:      fmt.Sprintf(":%d", constant.ServiceProxyPort),
-		TLSConfig: tlsConfig,
-		Handler:   s,
-	}
-
-	return httpserver.ListenAndServeTLS(s.cert, s.key)
+	klog.Infof("starting service proxy HTTPS server on %d and health server on 8000", constant.ServiceProxyPort)
+	return utils.RunHTTPServers(
+		runCtx,
+		utils.DefaultHTTPShutdownTimeout,
+		utils.RunnableHTTPServer{
+			Name:   "service proxy",
+			Server: publicServer,
+			Serve: func() error {
+				return publicServer.ListenAndServeTLS(s.cert, s.key)
+			},
+		},
+		utils.RunnableHTTPServer{
+			Name:   "health probe",
+			Server: healthServer,
+			Serve:  healthServer.ListenAndServe,
+		},
+	)
 }
 
 func (s *serviceProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -148,7 +148,11 @@ func (k *userServer) init(ctx context.Context) error {
 		return tunnel, nil
 	}
 
-	addonClient, err := addonclient.NewForConfig(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes config for add-on informer: %w", err)
+	}
+	addonClient, err := addonclient.NewForConfig(kubeConfig)
 	if err != nil {
 		return err
 	}
@@ -227,40 +231,47 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 }
 
 func (k *userServer) Run(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var err error
 
 	klog.Info("begin to run user server")
 
 	if err = k.Validate(); err != nil {
-		klog.Fatal(err)
+		return err
 	}
 
-	if err = k.init(ctx); err != nil {
-		klog.Fatal(err)
+	if err = k.init(runCtx); err != nil {
+		return err
 	}
 
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
-		klog.Fatalf("Pod namespace is empty, please set the ENV for POD_NAMESPACE")
+		return fmt.Errorf("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		klog.Fatalf("failed to create kube client for TLS watcher: %v", err)
+		return fmt.Errorf("failed to get Kubernetes config for TLS watcher: %w", err)
 	}
-	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, kubeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client for TLS watcher: %w", err)
+	}
+	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, kubeClient, podNamespace, func() {
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
-		klog.Fatalf("failed to start TLS ConfigMap watcher: %v", err)
+		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
 	}
 	klog.Infof("TLS config loaded: minVersion=%s, ciphersuites=%s", sdktls.VersionToString(sdkTLSConfig.MinVersion),
 		sdktls.CipherSuitesToString(sdkTLSConfig.CipherSuites))
 
 	cc, err := addonutils.NewConfigChecker("user-server", k.proxyCACertPath, k.proxyCertPath, k.proxyKeyPath, k.serverCert, k.serverKey, k.serviceProxyCACertPath)
 	if err != nil {
-		klog.Fatal(err)
+		return err
 	}
 
 	tlsConfig := &tls.Config{
@@ -268,28 +279,26 @@ func (k *userServer) Run(ctx context.Context) error {
 		CipherSuites: sdkTLSConfig.CipherSuites,
 	}
 
-	go func() {
-		// Currently ServeHealthProbes uses HTTP so our tlsConfig is not needed, however passing through for
-		// consistency and in case it's ever updated to use HTTPS in the future
-		if err = utils.ServeHealthProbes(":8000", tlsConfig, cc.Check); err != nil {
-			klog.Fatal(err)
-		}
-	}()
+	healthServer := utils.NewHealthProbeServer(":8000", tlsConfig, cc.Check)
+	publicServer := utils.NewHTTPServer(fmt.Sprintf(":%d", k.serverPort), tlsConfig, k)
 
-	klog.Infof("start https server on %d", k.serverPort)
-
-	s := &http.Server{
-		Addr:      fmt.Sprintf(":%d", k.serverPort),
-		TLSConfig: tlsConfig,
-		Handler:   k,
-	}
-
-	err = s.ListenAndServeTLS(k.serverCert, k.serverKey)
-	if err != nil {
-		klog.Fatalf("failed to start user proxy server: %v", err)
-	}
-
-	return nil
+	klog.Infof("starting user HTTPS server on %d and health server on 8000", k.serverPort)
+	return utils.RunHTTPServers(
+		runCtx,
+		utils.DefaultHTTPShutdownTimeout,
+		utils.RunnableHTTPServer{
+			Name:   "user proxy",
+			Server: publicServer,
+			Serve: func() error {
+				return publicServer.ListenAndServeTLS(k.serverCert, k.serverKey)
+			},
+		},
+		utils.RunnableHTTPServer{
+			Name:   "health probe",
+			Server: healthServer,
+			Serve:  healthServer.ListenAndServe,
+		},
+	)
 }
 
 // serviceProxyURL is used to generate the URL of the service proxy server.

--- a/pkg/utils/http_server.go
+++ b/pkg/utils/http_server.go
@@ -1,0 +1,349 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+const (
+	DefaultHTTPReadHeaderTimeout = 5 * time.Second
+	DefaultHTTPShutdownTimeout   = 30 * time.Second
+	httpForceCloseGracePeriod    = time.Second
+)
+
+// RunnableHTTPServer contains an HTTP server and its serve function.
+type RunnableHTTPServer struct {
+	Name   string
+	Server *http.Server
+	Serve  func() error
+}
+
+// NewHTTPServer creates an HTTP server for proxy traffic.
+func NewHTTPServer(address string, tlsConfig *tls.Config, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              address,
+		TLSConfig:         tlsConfig,
+		Handler:           handler,
+		ReadHeaderTimeout: DefaultHTTPReadHeaderTimeout,
+	}
+}
+
+// NewHealthProbeServer creates an HTTP server for health probes and config checks.
+func NewHealthProbeServer(healthProbeBindAddress string, tlsConfig *tls.Config, customChecks ...healthz.Checker) *http.Server {
+	mux := http.NewServeMux()
+
+	checks := map[string]healthz.Checker{
+		"healthz-ping": healthz.Ping,
+	}
+
+	for i, check := range customChecks {
+		checks[fmt.Sprintf("custom-healthz-checker-%d", i)] = check
+	}
+
+	mux.Handle("/healthz", http.StripPrefix("/healthz", &healthz.Handler{Checks: checks}))
+	return NewHTTPServer(healthProbeBindAddress, tlsConfig, mux)
+}
+
+type serverConnectionContextKey struct{}
+
+type httpServerLifecycle struct {
+	mu sync.Mutex
+
+	inFlight   int
+	hijacked   map[net.Conn]struct{}
+	idle       chan struct{}
+	cancelBase context.CancelFunc
+}
+
+func newHTTPServerLifecycle() *httpServerLifecycle {
+	idle := make(chan struct{})
+	close(idle)
+	return &httpServerLifecycle{
+		hijacked: make(map[net.Conn]struct{}),
+		idle:     idle,
+	}
+}
+
+func (l *httpServerLifecycle) startRequest() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.inFlight == 0 {
+		l.idle = make(chan struct{})
+	}
+	l.inFlight++
+}
+
+func (l *httpServerLifecycle) finishRequest(connection net.Conn) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.inFlight--
+	delete(l.hijacked, connection)
+	if l.inFlight == 0 {
+		close(l.idle)
+	}
+}
+
+func (l *httpServerLifecycle) updateConnectionState(connection net.Conn, state http.ConnState) {
+	// StateHijacked is terminal; finishRequest removes the connection.
+	if state != http.StateHijacked {
+		return
+	}
+	l.mu.Lock()
+	l.hijacked[connection] = struct{}{}
+	l.mu.Unlock()
+}
+
+func (l *httpServerLifecycle) wait(ctx context.Context) error {
+	l.mu.Lock()
+	idle := l.idle
+	l.mu.Unlock()
+
+	select {
+	case <-idle:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l *httpServerLifecycle) forceClose() []error {
+	l.mu.Lock()
+	connections := make([]net.Conn, 0, len(l.hijacked))
+	for connection := range l.hijacked {
+		connections = append(connections, connection)
+	}
+	l.mu.Unlock()
+
+	l.cancelBase()
+
+	var errs []error
+	// Hijacked connections ignore context cancellation.
+	for _, connection := range connections {
+		if err := connection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+type lifecycleHandler struct {
+	lifecycle *httpServerLifecycle
+	handler   http.Handler
+}
+
+func (h *lifecycleHandler) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	h.lifecycle.startRequest()
+	connection, _ := request.Context().Value(serverConnectionContextKey{}).(net.Conn)
+	defer h.lifecycle.finishRequest(connection)
+
+	h.handler.ServeHTTP(w, request)
+}
+
+func prepareHTTPServer(server *http.Server) *httpServerLifecycle {
+	lifecycle := newHTTPServerLifecycle()
+	handler := server.Handler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	server.Handler = &lifecycleHandler{lifecycle: lifecycle, handler: handler}
+
+	// A shared base context lets forceClose cancel all active requests.
+	forceCloseCtx, cancelBase := context.WithCancel(context.Background())
+	lifecycle.cancelBase = cancelBase
+	previousBaseContext := server.BaseContext
+	server.BaseContext = func(listener net.Listener) context.Context {
+		baseCtx := context.Background()
+		if previousBaseContext != nil {
+			baseCtx = previousBaseContext(listener)
+		}
+		requestBaseCtx, cancelRequestBase := context.WithCancel(baseCtx)
+		context.AfterFunc(forceCloseCtx, cancelRequestBase)
+		return requestBaseCtx
+	}
+
+	previousConnContext := server.ConnContext
+	server.ConnContext = func(ctx context.Context, connection net.Conn) context.Context {
+		if previousConnContext != nil {
+			ctx = previousConnContext(ctx, connection)
+		}
+		return context.WithValue(ctx, serverConnectionContextKey{}, connection)
+	}
+
+	previousConnState := server.ConnState
+	server.ConnState = func(connection net.Conn, state http.ConnState) {
+		lifecycle.updateConnectionState(connection, state)
+		if previousConnState != nil {
+			previousConnState(connection, state)
+		}
+	}
+	return lifecycle
+}
+
+type httpServerResult struct {
+	name string
+	err  error
+}
+
+// RunHTTPServers serves until the context is canceled or a server stops, then
+// drains active and hijacked requests within shutdownTimeout.
+func RunHTTPServers(ctx context.Context, shutdownTimeout time.Duration, servers ...RunnableHTTPServer) error {
+	if err := validateHTTPServers(servers); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	lifecycles := make([]*httpServerLifecycle, 0, len(servers))
+	for _, server := range servers {
+		lifecycles = append(lifecycles, prepareHTTPServer(server.Server))
+	}
+	defer func() {
+		for _, lifecycle := range lifecycles {
+			lifecycle.cancelBase()
+		}
+	}()
+
+	results := make(chan httpServerResult, len(servers))
+	for _, server := range servers {
+		go func() {
+			results <- httpServerResult{name: server.Name, err: server.Serve()}
+		}()
+	}
+
+	var completed []httpServerResult
+	select {
+	case <-ctx.Done():
+	case result := <-results:
+		completed = append(completed, result)
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancelShutdown()
+
+	shutdownResults := make(chan httpServerResult, len(servers))
+	for _, server := range servers {
+		go func() {
+			shutdownResults <- httpServerResult{
+				name: server.Name,
+				err:  server.Server.Shutdown(shutdownCtx),
+			}
+		}()
+	}
+
+	var errs []error
+	for range servers {
+		result := <-shutdownResults
+		if result.err != nil && !errors.Is(result.err, http.ErrServerClosed) {
+			errs = append(errs, fmt.Errorf("shut down %s HTTP server: %w", result.name, result.err))
+		}
+	}
+
+	drainErr := waitForHTTPHandlers(shutdownCtx, lifecycles)
+	if drainErr != nil {
+		errs = append(errs, fmt.Errorf("drain HTTP handlers: %w", drainErr))
+	}
+
+	if len(errs) > 0 {
+		for i, lifecycle := range lifecycles {
+			for _, err := range lifecycle.forceClose() {
+				errs = append(errs, fmt.Errorf("close hijacked connection for %s HTTP server: %w", servers[i].Name, err))
+			}
+		}
+		for _, result := range closeHTTPServers(servers) {
+			if result.err != nil && !errors.Is(result.err, http.ErrServerClosed) {
+				errs = append(errs, fmt.Errorf("force close %s HTTP server: %w", result.name, result.err))
+			}
+		}
+
+		forceCtx, cancelForce := context.WithTimeout(context.Background(), httpForceCloseGracePeriod)
+		if err := waitForHTTPHandlers(forceCtx, lifecycles); err != nil {
+			errs = append(errs, fmt.Errorf("wait for forced HTTP handler close: %w", err))
+		}
+		completed = collectHTTPServerResults(forceCtx, results, completed, len(servers), &errs)
+		cancelForce()
+	} else {
+		stopCtx, cancelStop := context.WithTimeout(context.Background(), httpForceCloseGracePeriod)
+		completed = collectHTTPServerResults(stopCtx, results, completed, len(servers), &errs)
+		cancelStop()
+	}
+
+	for _, result := range completed {
+		if result.err != nil && !errors.Is(result.err, http.ErrServerClosed) {
+			errs = append(errs, fmt.Errorf("%s HTTP server failed: %w", result.name, result.err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateHTTPServers(servers []RunnableHTTPServer) error {
+	if len(servers) == 0 {
+		return fmt.Errorf("at least one HTTP server is required")
+	}
+	for _, server := range servers {
+		if server.Name == "" {
+			return fmt.Errorf("HTTP server name is required")
+		}
+		if server.Server == nil {
+			return fmt.Errorf("%s HTTP server is required", server.Name)
+		}
+		if server.Serve == nil {
+			return fmt.Errorf("%s HTTP server serve function is required", server.Name)
+		}
+	}
+	return nil
+}
+
+func waitForHTTPHandlers(ctx context.Context, lifecycles []*httpServerLifecycle) error {
+	for _, lifecycle := range lifecycles {
+		if err := lifecycle.wait(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func closeHTTPServers(servers []RunnableHTTPServer) []httpServerResult {
+	results := make(chan httpServerResult, len(servers))
+	for _, server := range servers {
+		go func() {
+			results <- httpServerResult{name: server.Name, err: server.Server.Close()}
+		}()
+	}
+
+	completed := make([]httpServerResult, 0, len(servers))
+	for range servers {
+		completed = append(completed, <-results)
+	}
+	return completed
+}
+
+func collectHTTPServerResults(
+	ctx context.Context,
+	results <-chan httpServerResult,
+	completed []httpServerResult,
+	total int,
+	errs *[]error,
+) []httpServerResult {
+	for len(completed) < total {
+		select {
+		case result := <-results:
+			completed = append(completed, result)
+		case <-ctx.Done():
+			*errs = append(*errs, fmt.Errorf("wait for HTTP servers to stop: %w", ctx.Err()))
+			return completed
+		}
+	}
+	return completed
+}

--- a/pkg/utils/http_server_test.go
+++ b/pkg/utils/http_server_test.go
@@ -1,0 +1,431 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServerConfiguresHeaderTimeoutWithoutBreakingStreaming(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	server := NewHTTPServer("127.0.0.1:8443", tlsConfig, handler)
+
+	if server.Addr != "127.0.0.1:8443" {
+		t.Fatalf("unexpected address: %q", server.Addr)
+	}
+	if server.TLSConfig != tlsConfig {
+		t.Fatal("TLS config was not preserved")
+	}
+	if server.Handler == nil {
+		t.Fatal("handler was not configured")
+	}
+	if server.ReadHeaderTimeout != DefaultHTTPReadHeaderTimeout {
+		t.Fatalf("unexpected ReadHeaderTimeout: %v", server.ReadHeaderTimeout)
+	}
+	if server.WriteTimeout != 0 {
+		t.Fatalf("WriteTimeout must remain unset for streaming requests, got %v", server.WriteTimeout)
+	}
+
+	healthServer := NewHealthProbeServer("127.0.0.1:8000", tlsConfig)
+	if healthServer.ReadHeaderTimeout != DefaultHTTPReadHeaderTimeout {
+		t.Fatalf("health server has unexpected ReadHeaderTimeout: %v", healthServer.ReadHeaderTimeout)
+	}
+	if healthServer.WriteTimeout != 0 {
+		t.Fatalf("health server has unexpected WriteTimeout: %v", healthServer.WriteTimeout)
+	}
+}
+
+func TestPrepareHTTPServerPreservesAndCancelsBaseContext(t *testing.T) {
+	type contextKey struct{}
+
+	t.Run("preserves parent values and cancellation", func(t *testing.T) {
+		parentCtx, cancelParent := context.WithCancel(
+			context.WithValue(context.Background(), contextKey{}, "parent-value"),
+		)
+		server := NewHTTPServer("", nil, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		server.BaseContext = func(net.Listener) context.Context {
+			return parentCtx
+		}
+		lifecycle := prepareHTTPServer(server)
+		t.Cleanup(lifecycle.cancelBase)
+
+		baseCtx := server.BaseContext(nil)
+		if got := baseCtx.Value(contextKey{}); got != "parent-value" {
+			t.Fatalf("base context value was not preserved: got %v", got)
+		}
+
+		cancelParent()
+		select {
+		case <-baseCtx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("parent cancellation did not reach the wrapped base context")
+		}
+	})
+
+	t.Run("propagates lifecycle cancellation", func(t *testing.T) {
+		server := NewHTTPServer("", nil, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		lifecycle := prepareHTTPServer(server)
+		baseCtx := server.BaseContext(nil)
+
+		lifecycle.cancelBase()
+		select {
+		case <-baseCtx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("lifecycle cancellation did not reach the wrapped base context")
+		}
+	})
+}
+
+func TestRunHTTPServersDrainsActiveRequestOnCancellation(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := NewHTTPServer("", nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		_, _ = io.WriteString(w, "drained")
+	}))
+	listener := newTestListener(t)
+	serveStarted := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- RunHTTPServers(ctx, time.Second, RunnableHTTPServer{
+			Name:   "public",
+			Server: server,
+			Serve: func() error {
+				close(serveStarted)
+				return server.Serve(listener)
+			},
+		})
+	}()
+	<-serveStarted
+
+	client := &http.Client{Timeout: time.Second}
+	responseResult := make(chan error, 1)
+	go func() {
+		response, err := client.Get("http://" + listener.Addr().String())
+		if err != nil {
+			responseResult <- err
+			return
+		}
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		if err == nil && string(body) != "drained" {
+			err = errors.New("response was not drained")
+		}
+		responseResult <- err
+	}()
+	<-requestStarted
+
+	cancel()
+	select {
+	case err := <-runResult:
+		t.Fatalf("server returned before the active request drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseRequest)
+	if err := <-responseResult; err != nil {
+		t.Fatalf("active request failed during graceful shutdown: %v", err)
+	}
+	if err := <-runResult; err != nil {
+		t.Fatalf("graceful shutdown returned an error: %v", err)
+	}
+}
+
+func TestRunHTTPServersPropagatesFailureAndStopsPeer(t *testing.T) {
+	listener := newTestListener(t)
+	peer := NewHTTPServer("", nil, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	peerStarted := make(chan struct{})
+	wantErr := errors.New("health listener failed")
+
+	err := RunHTTPServers(context.Background(), time.Second,
+		RunnableHTTPServer{
+			Name:   "public",
+			Server: peer,
+			Serve: func() error {
+				close(peerStarted)
+				return peer.Serve(listener)
+			},
+		},
+		RunnableHTTPServer{
+			Name:   "health probe",
+			Server: &http.Server{},
+			Serve: func() error {
+				<-peerStarted
+				return wantErr
+			},
+		},
+	)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("server failure was not propagated: %v", err)
+	}
+	connection, dialErr := net.DialTimeout("tcp", listener.Addr().String(), 100*time.Millisecond)
+	if dialErr == nil {
+		connection.Close()
+		t.Fatal("peer listener remained open after another server failed")
+	}
+}
+
+func TestRunHTTPServersForcesCloseAfterShutdownTimeout(t *testing.T) {
+	requestStarted := make(chan struct{})
+
+	server := NewHTTPServer("", nil, http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestStarted)
+		<-request.Context().Done()
+	}))
+	listener := newTestListener(t)
+	serveStarted := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- RunHTTPServers(ctx, 20*time.Millisecond, RunnableHTTPServer{
+			Name:   "public",
+			Server: server,
+			Serve: func() error {
+				close(serveStarted)
+				return server.Serve(listener)
+			},
+		})
+	}()
+	<-serveStarted
+
+	client := &http.Client{Timeout: time.Second}
+	requestResult := make(chan error, 1)
+	go func() {
+		response, err := client.Get("http://" + listener.Addr().String())
+		if response != nil {
+			response.Body.Close()
+		}
+		requestResult <- err
+	}()
+	<-requestStarted
+	cancel()
+
+	select {
+	case err := <-runResult:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected shutdown deadline error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown timeout did not bound server termination")
+	}
+	<-requestResult
+}
+
+func TestRunHTTPServersWaitsForHijackedRequestToCloseNaturally(t *testing.T) {
+	hijacked := make(chan struct{})
+	handlerEnded := make(chan struct{})
+	handlerErr := make(chan error, 1)
+	server := NewHTTPServer("", nil, upgradedConnectionHandler(hijacked, handlerEnded, handlerErr))
+	observedHijack := make(chan struct{})
+	var observedHijackOnce sync.Once
+	server.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateHijacked {
+			observedHijackOnce.Do(func() {
+				close(observedHijack)
+			})
+		}
+	}
+	listener := newTestListener(t)
+	serveStarted := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- RunHTTPServers(ctx, time.Second, RunnableHTTPServer{
+			Name:   "public",
+			Server: server,
+			Serve: func() error {
+				close(serveStarted)
+				return server.Serve(listener)
+			},
+		})
+	}()
+	<-serveStarted
+
+	connection := openUpgradedConnection(t, listener.Addr().String())
+	<-hijacked
+	<-observedHijack
+	cancel()
+
+	select {
+	case err := <-runResult:
+		t.Fatalf("server returned before hijacked request closed naturally: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := connection.Close(); err != nil {
+		t.Fatalf("close upgraded client connection: %v", err)
+	}
+	<-handlerEnded
+	select {
+	case err := <-handlerErr:
+		t.Fatalf("upgraded handler failed: %v", err)
+	default:
+	}
+	if err := <-runResult; err != nil {
+		t.Fatalf("natural upgraded connection drain returned an error: %v", err)
+	}
+}
+
+func TestRunHTTPServersForceClosesHijackedRequestAtDeadline(t *testing.T) {
+	hijacked := make(chan struct{})
+	handlerEnded := make(chan struct{})
+	handlerErr := make(chan error, 1)
+	server := NewHTTPServer("", nil, upgradedConnectionHandler(hijacked, handlerEnded, handlerErr))
+	listener := newTestListener(t)
+	serveStarted := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- RunHTTPServers(ctx, 30*time.Millisecond, RunnableHTTPServer{
+			Name:   "public",
+			Server: server,
+			Serve: func() error {
+				close(serveStarted)
+				return server.Serve(listener)
+			},
+		})
+	}()
+	<-serveStarted
+
+	connection := openUpgradedConnection(t, listener.Addr().String())
+	defer connection.Close()
+	<-hijacked
+	cancel()
+
+	if err := connection.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set upgraded connection read deadline: %v", err)
+	}
+	if _, err := connection.Read(make([]byte, 1)); err == nil {
+		t.Fatal("upgraded client connection remained open after shutdown deadline")
+	}
+
+	select {
+	case <-handlerEnded:
+	case <-time.After(time.Second):
+		t.Fatal("hijacked handler did not end after its connection was force-closed")
+	}
+	select {
+	case err := <-handlerErr:
+		t.Fatalf("upgraded handler failed: %v", err)
+	default:
+	}
+	select {
+	case err := <-runResult:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected shutdown deadline error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("force-closing hijacked request exceeded cleanup grace")
+	}
+}
+
+func upgradedConnectionHandler(
+	hijacked chan<- struct{},
+	ended chan<- struct{},
+	handlerErr chan<- error,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		defer close(ended)
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			handlerErr <- errors.New("response writer does not implement http.Hijacker")
+			return
+		}
+		connection, buffered, err := hijacker.Hijack()
+		if err != nil {
+			handlerErr <- fmt.Errorf("hijack connection: %w", err)
+			return
+		}
+		defer connection.Close()
+
+		if _, err := buffered.WriteString(
+			"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n",
+		); err != nil {
+			handlerErr <- fmt.Errorf("write upgrade response: %w", err)
+			return
+		}
+		if err := buffered.Flush(); err != nil {
+			handlerErr <- fmt.Errorf("flush upgrade response: %w", err)
+			return
+		}
+		close(hijacked)
+
+		_, _ = io.Copy(io.Discard, connection)
+	})
+}
+
+func openUpgradedConnection(t *testing.T, address string) net.Conn {
+	t.Helper()
+
+	connection, err := net.DialTimeout("tcp", address, time.Second)
+	if err != nil {
+		t.Fatalf("dial upgrade server: %v", err)
+	}
+	if err := connection.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		connection.Close()
+		t.Fatalf("set upgrade handshake deadline: %v", err)
+	}
+	if _, err := fmt.Fprintf(
+		connection,
+		"GET /upgrade HTTP/1.1\r\nHost: %s\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n",
+		address,
+	); err != nil {
+		connection.Close()
+		t.Fatalf("write upgrade request: %v", err)
+	}
+
+	reader := bufio.NewReader(connection)
+	status, err := reader.ReadString('\n')
+	if err != nil {
+		connection.Close()
+		t.Fatalf("read upgrade status: %v", err)
+	}
+	if !strings.Contains(status, "101 Switching Protocols") {
+		connection.Close()
+		t.Fatalf("unexpected upgrade status: %q", status)
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			connection.Close()
+			t.Fatalf("read upgrade headers: %v", err)
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+	if err := connection.SetDeadline(time.Time{}); err != nil {
+		connection.Close()
+		t.Fatalf("clear upgrade handshake deadline: %v", err)
+	}
+	return connection
+}
+
+func newTestListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	return listener
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,16 +1,12 @@
 package utils
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 const (
@@ -156,28 +152,4 @@ func GetProxyType(reqURI string) int {
 		return ProxyTypeService
 	}
 	return ProxyTypeKubeAPIServer
-}
-
-// ServeHealthProbes serves health probes and configchecker.
-func ServeHealthProbes(healthProbeBindAddress string, tlsConfig *tls.Config, customChecks ...healthz.Checker) error {
-	mux := http.NewServeMux()
-
-	checks := map[string]healthz.Checker{
-		"healthz-ping": healthz.Ping,
-	}
-
-	for i, check := range customChecks {
-		checks[fmt.Sprintf("custom-healthz-checker-%d", i)] = check
-	}
-
-	mux.Handle("/healthz", http.StripPrefix("/healthz", &healthz.Handler{Checks: checks}))
-	server := http.Server{
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-		Addr:              healthProbeBindAddress,
-		// TLS config is currently unused, as below we are using ListenAndServe() which will serve HTTP
-		TLSConfig: tlsConfig,
-	}
-	klog.Infof("heath probes server is running...")
-	return server.ListenAndServe()
 }


### PR DESCRIPTION
Some proxy shutdown paths call `klog.Fatal` or `os.Exit`, so TLS certificate rotation can interrupt active requests and upgraded connections such as `kubectl exec` and `port-forward`.

Route shutdown through context cancellation, drain HTTP servers within a timeout, force-close hijacked connections at the deadline, and give the pods enough termination grace time to finish.
