### PR TITLE
:bug: restart hub manager gracefully on TLS changes

### DIFF
--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         component: cluster-proxy-manager
     spec:
       serviceAccount: cluster-proxy
+      # Binaries drain for up to 30s after SIGTERM; the extra 10s lets forced
+      # cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/cmd/addon-manager/main.go
+++ b/cmd/addon-manager/main.go
@@ -183,8 +183,8 @@ func main() {
 	// So we could alternatively add a watch there on the configmap and simply reconcile.
 	// This way keeps it simpler with common code, but does restart when the configmap changes
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, nativeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
 		setupLog.Error(err, "failed to start TLS ConfigMap watcher")


### PR DESCRIPTION
Fixes the addon-manager killing itself with `os.Exit(0)` on TLS ConfigMap changes, which skipped graceful shutdown.