### PR TITLE
:seedling: return errors instead of exiting mid-setup

### DIFF
--- a/cmd/cluster-proxy/main.go
+++ b/cmd/cluster-proxy/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	goflag "flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -24,24 +26,37 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	os.Exit(runMain(execute, os.Stderr, logs.FlushLogs))
+}
 
-	command := newClusterProxyCommand()
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+func runMain(executeCommand func() error, stderr io.Writer, flushLogs func()) int {
+	defer flushLogs()
+
+	if err := executeCommand(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
+
+	return 0
+}
+
+func execute() error {
+	return newClusterProxyCommand().Execute()
 }
 
 func newClusterProxyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-proxy",
 		Short: "cluster-proxy",
-		Run: func(cmd *cobra.Command, args []string) {
+		// runMain prints returned errors; keep Cobra from printing them again.
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmd.Help(); err != nil {
-				klog.Errorf("cmd help err: %v", err)
+				return err
 			}
-			os.Exit(1)
+			// The help text above already covers usage.
+			cmd.SilenceUsage = true
+			return errors.New("a subcommand is required")
 		},
 	}
 

--- a/cmd/cluster-proxy/main_test.go
+++ b/cmd/cluster-proxy/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunMain(t *testing.T) {
+	tests := []struct {
+		name         string
+		execute      func() error
+		wantExitCode int
+		wantStderr   string
+		wantFlushes  int
+	}{
+		{
+			name:         "success",
+			execute:      func() error { return nil },
+			wantExitCode: 0,
+			wantFlushes:  1,
+		},
+		{
+			name:         "error",
+			execute:      func() error { return errors.New("boom") },
+			wantExitCode: 1,
+			wantStderr:   "boom\n",
+			wantFlushes:  1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stderr strings.Builder
+			flushes := 0
+
+			exitCode := runMain(test.execute, &stderr, func() {
+				flushes++
+			})
+
+			if exitCode != test.wantExitCode {
+				t.Errorf("exit code = %d, want %d", exitCode, test.wantExitCode)
+			}
+			if stderr.String() != test.wantStderr {
+				t.Errorf("stderr = %q, want %q", stderr.String(), test.wantStderr)
+			}
+			if flushes != test.wantFlushes {
+				t.Errorf("flush count = %d, want %d", flushes, test.wantFlushes)
+			}
+		})
+	}
+}

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -45,11 +45,8 @@ func NewControllersCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controllers",
 		Short: "controllers",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := runControllerManager()
-			if err != nil {
-				klog.Fatal(err, "unable to run controller manager")
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runControllerManager()
 		},
 	}
 
@@ -71,12 +68,15 @@ func runControllerManager() error {
 	defer cancel()
 
 	// Setup clients, informers and listers.
-	kubeConfig := config.GetConfigOrDie()
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get Kubernetes config: %w", err)
+	}
 
 	// secret client and lister
 	nativeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("create Kubernetes client: %w", err)
 	}
 	secertClient := nativeClient.CoreV1()
 	informerFactory := informers.NewSharedInformerFactory(nativeClient, 10*time.Minute)
@@ -99,20 +99,18 @@ func runControllerManager() error {
 	})
 	if err != nil {
 		klog.Error(err, "unable to set up overall controller manager")
-		return err
+		return fmt.Errorf("set up controller manager: %w", err)
 	}
 
 	// loading ManagedProxyConfiguration for owner reference
 	proxyClient, err := proxyclient.NewForConfig(mgr.GetConfig())
 	if err != nil {
-		klog.Error(err, "unable to set up proxy client")
-		os.Exit(1)
+		return fmt.Errorf("set up proxy client: %w", err)
 	}
 	proxyConfig, err := proxyClient.ProxyV1alpha1().ManagedProxyConfigurations().Get(
 		context.TODO(), "cluster-proxy", metav1.GetOptions{})
 	if err != nil {
-		klog.Error(err, "failed to get ManagedProxyConfiguration 'cluster-proxy'")
-		os.Exit(1)
+		return fmt.Errorf("get ManagedProxyConfiguration %q: %w", "cluster-proxy", err)
 	}
 	ownerRef := selfsigned.NewOwnerReferenceFromConfig(proxyConfig)
 
@@ -121,12 +119,12 @@ func runControllerManager() error {
 		secertLister, secertClient, ownerRef, mgr)
 	if err != nil {
 		klog.Error(err, "unable to set up cert-controller")
-		return err
+		return fmt.Errorf("set up cert controller: %w", err)
 	}
 
 	if err := mgr.Start(ctx); err != nil {
 		klog.Error(err, "problem running manager")
-		return err
+		return fmt.Errorf("run controller manager: %w", err)
 	}
 	return nil
 }

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -262,7 +262,7 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
-		klog.Fatalf("Pod namespace is empty, please set the ENV for POD_NAMESPACE")
+		return errors.New("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, s.managedClusterKubeClient, podNamespace, func() {
@@ -270,7 +270,7 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		os.Exit(0)
 	})
 	if err != nil {
-		klog.Fatalf("failed to start TLS ConfigMap watcher: %v", err)
+		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
 	}
 	klog.Infof("TLS config loaded: minVersion=%s, ciphersuites=%s", sdktls.VersionToString(sdkTLSConfig.MinVersion),
 		sdktls.CipherSuitesToString(sdkTLSConfig.CipherSuites))

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -148,9 +148,13 @@ func (k *userServer) init(ctx context.Context) error {
 		return tunnel, nil
 	}
 
-	addonClient, err := addonclient.NewForConfig(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get Kubernetes config for add-on informer: %w", err)
+	}
+	addonClient, err := addonclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create add-on client: %w", err)
 	}
 	addonInformerFactory := addoninformers.NewSharedInformerFactory(addonClient, 30*time.Minute)
 	k.addonLister = addonInformerFactory.Addon().V1beta1().ManagedClusterAddOns().Lister()
@@ -232,35 +236,39 @@ func (k *userServer) Run(ctx context.Context) error {
 	klog.Info("begin to run user server")
 
 	if err = k.Validate(); err != nil {
-		klog.Fatal(err)
+		return err
 	}
 
 	if err = k.init(ctx); err != nil {
-		klog.Fatal(err)
+		return err
 	}
 
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
-		klog.Fatalf("Pod namespace is empty, please set the ENV for POD_NAMESPACE")
+		return fmt.Errorf("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(ctrl.GetConfigOrDie())
+	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		klog.Fatalf("failed to create kube client for TLS watcher: %v", err)
+		return fmt.Errorf("failed to get Kubernetes config for TLS watcher: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client for TLS watcher: %w", err)
 	}
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, kubeClient, podNamespace, func() {
 		klog.Info("TLS ConfigMap changed, restarting")
 		os.Exit(0)
 	})
 	if err != nil {
-		klog.Fatalf("failed to start TLS ConfigMap watcher: %v", err)
+		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
 	}
 	klog.Infof("TLS config loaded: minVersion=%s, ciphersuites=%s", sdktls.VersionToString(sdkTLSConfig.MinVersion),
 		sdktls.CipherSuitesToString(sdkTLSConfig.CipherSuites))
 
 	cc, err := addonutils.NewConfigChecker("user-server", k.proxyCACertPath, k.proxyCertPath, k.proxyKeyPath, k.serverCert, k.serverKey, k.serviceProxyCACertPath)
 	if err != nil {
-		klog.Fatal(err)
+		return fmt.Errorf("failed to create config checker: %w", err)
 	}
 
 	tlsConfig := &tls.Config{
@@ -286,7 +294,7 @@ func (k *userServer) Run(ctx context.Context) error {
 
 	err = s.ListenAndServeTLS(k.serverCert, k.serverKey)
 	if err != nil {
-		klog.Fatalf("failed to start user proxy server: %v", err)
+		return fmt.Errorf("failed to start user proxy server: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The setup paths in the cluster-proxy binaries exit through `klog.Fatal` / `os.Exit`, which skips deferred cleanup and the log flush (golangci's exitAfterDefer flags two of these on main today). This converts them to returned errors and lets `main` print the error and pick the exit code. The root command now requires a subcommand via `RunE`.

No signal handling is touched and there's no behavior change beyond the error output. Groundwork for the shutdown draining change.

Split out of open-cluster-management-io/cluster-proxy#339.