### PR TITLE
:sparkles: drain proxy HTTP requests on shutdown

### DIFF
--- a/charts/cluster-proxy/templates/manager-deployment.yaml
+++ b/charts/cluster-proxy/templates/manager-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         component: cluster-proxy-manager
     spec:
       serviceAccount: cluster-proxy
-      # Binaries drain for up to 30s after SIGTERM; the extra 10s lets forced
+      # Shutdown can take up to 30s after SIGTERM; the extra 10s lets process
       # cleanup finish before the kubelet sends SIGKILL.
       terminationGracePeriodSeconds: 40
       securityContext:

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         component: cluster-proxy-addon-user
     spec:
       serviceAccount: cluster-proxy
+      # By default, shutdown can take up to 30s after SIGTERM; the extra 10s
+      # lets process cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -73,6 +76,11 @@ spec:
             privileged: false
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            periodSeconds: 2
           volumeMounts:
             - name: user-tls-vol
               mountPath: /user-tls

--- a/cmd/cluster-proxy/main.go
+++ b/cmd/cluster-proxy/main.go
@@ -13,6 +13,7 @@ import (
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"open-cluster-management.io/cluster-proxy/pkg/controllers"
 	"open-cluster-management.io/cluster-proxy/pkg/serviceproxy"
@@ -41,7 +42,7 @@ func runMain(executeCommand func() error, stderr io.Writer, flushLogs func()) in
 }
 
 func execute() error {
-	return newClusterProxyCommand().Execute()
+	return newClusterProxyCommand().ExecuteContext(signals.SetupSignalHandler())
 }
 
 func newClusterProxyCommand() *cobra.Command {

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"open-cluster-management.io/cluster-proxy/pkg/proxyserver/operator/authentication/selfsigned"
@@ -46,7 +45,7 @@ func NewControllersCommand() *cobra.Command {
 		Use:   "controllers",
 		Short: "controllers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runControllerManager()
+			return runControllerManager(cmd.Context())
 		},
 	}
 
@@ -63,10 +62,7 @@ func addFlags(cmd *cobra.Command) {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 }
 
-func runControllerManager() error {
-	ctx, cancel := context.WithCancel(signals.SetupSignalHandler())
-	defer cancel()
-
+func runControllerManager(ctx context.Context) error {
 	// Setup clients, informers and listers.
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -108,7 +104,7 @@ func runControllerManager() error {
 		return fmt.Errorf("set up proxy client: %w", err)
 	}
 	proxyConfig, err := proxyClient.ProxyV1alpha1().ManagedProxyConfigurations().Get(
-		context.TODO(), "cluster-proxy", metav1.GetOptions{})
+		ctx, "cluster-proxy", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get ManagedProxyConfiguration %q: %w", "cluster-proxy", err)
 	}

--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -42,7 +42,6 @@ import (
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
-	"open-cluster-management.io/cluster-proxy/pkg/constant"
 	"open-cluster-management.io/cluster-proxy/pkg/proxyserver/operator/authentication/selfsigned"
 )
 
@@ -505,8 +504,9 @@ func TestNewAgentAddon(t *testing.T) {
 				serviceProxy := getDeploymentContainer(agentDeploy, "service-proxy")
 				if assert.NotNil(t, serviceProxy) {
 					if assert.NotNil(t, serviceProxy.ReadinessProbe) &&
-						assert.NotNil(t, serviceProxy.ReadinessProbe.TCPSocket) {
-						assert.Equal(t, int32(constant.ServiceProxyPort), serviceProxy.ReadinessProbe.TCPSocket.Port.IntVal)
+						assert.NotNil(t, serviceProxy.ReadinessProbe.HTTPGet) {
+						assert.Equal(t, "/readyz", serviceProxy.ReadinessProbe.HTTPGet.Path)
+						assert.Equal(t, int32(8000), serviceProxy.ReadinessProbe.HTTPGet.Port.IntVal)
 					}
 					// oidc flags must not be rendered when the oidc variables are unset
 					for _, arg := range serviceProxy.Args {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - {{ .Values.serviceProxyHost }}
       {{- end }}
       serviceAccount: cluster-proxy
+      # By default, shutdown can take up to 30s after SIGTERM; the extra 10s
+      # lets process cleanup finish before the kubelet sends SIGKILL.
+      terminationGracePeriodSeconds: 40
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -218,8 +221,9 @@ spec:
             initialDelaySeconds: 2
             periodSeconds: 10
           readinessProbe:
-            tcpSocket:
-              port: 7443
+            httpGet:
+              path: /readyz
+              port: 8000
             periodSeconds: 2
           securityContext:
             allowPrivilegeEscalation: false

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -627,3 +627,47 @@ user-server -> tunnel -> service-proxy -> OIDC verification
 
 It also verifies the impersonated identity, denial before RBAC is granted, and
 successful authorization after the matching RoleBinding is created.
+
+## Graceful shutdown
+
+The user-server and service-proxy drain HTTP requests on SIGTERM and TLS
+configuration reloads:
+
+1. The readiness endpoint starts returning an error so Services and load
+   balancers can remove the Pod from rotation.
+2. The public listener remains available for at least 10 seconds by default,
+   allowing endpoint updates to propagate.
+3. The listener stops accepting new connections, idle HTTP connections close,
+   and the server waits for active requests managed by `net/http` until they
+   finish or the 30-second drain deadline expires.
+4. The process exits, disconnecting any requests or upgraded connections still
+   open.
+
+Connections hijacked from `net/http`, including WebSocket and SPDY exec,
+attach, and port-forward sessions, are not included in the drain. Waiting for
+them could allow some sessions to close naturally, but cluster-proxy cannot
+send a common shutdown notification or transfer them to another Pod. The
+implementation therefore favors the standard `http.Server.Shutdown` lifecycle
+over custom TCP connection tracking. The minimum drain duration is included in
+the overall timeout rather than added to it.
+
+On a TLS configuration change, the affected container completes this shutdown
+flow and exits. The kubelet then restarts that container in the existing Pod so
+it loads the new configuration.
+
+The `user-server` and `service-proxy` subcommands accept `--drain-timeout` and
+`--min-drain-duration`. Both values must be non-negative, and the minimum
+duration must not exceed the overall timeout. Set both to `0` for immediate
+shutdown. The controller subcommand uses controller-runtime's graceful
+shutdown default.
+
+Service-proxy flags can be overridden by adding the following fragment to the
+existing `ManagedProxyConfiguration`:
+
+```yaml
+spec:
+  proxyAgent:
+    additionalServiceProxyArgs:
+    - --drain-timeout=20s
+    - --min-drain-duration=5s
+```

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -74,6 +74,7 @@ type serviceProxy struct {
 	idleConnTimeout       time.Duration
 	tLSHandshakeTimeout   time.Duration
 	expectContinueTimeout time.Duration
+	drain                 utils.DrainConfig
 
 	tokenReviewCacheTTL time.Duration
 	kubeClientQPS       float32
@@ -129,6 +130,7 @@ func (s *serviceProxy) AddFlags(cmd *cobra.Command) {
 	flags.DurationVar(&s.idleConnTimeout, "idle-conn-timeout", 90*time.Second, "The maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.")
 	flags.DurationVar(&s.tLSHandshakeTimeout, "tls-handshake-timeout", 10*time.Second, "The maximum amount of time waiting to wait for a TLS handshake.")
 	flags.DurationVar(&s.expectContinueTimeout, "expect-continue-timeout", 1*time.Second, "The amount of time to wait for a server's first response headers after fully writing the request headers if the request has an \"Expect: 100-continue\" header.")
+	s.drain.AddFlags(flags)
 	flags.BoolVar(&s.enableImpersonation, "enable-impersonation", true, "Whether to enable impersonation")
 
 	// token review cache flags
@@ -155,6 +157,9 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	const (
 		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	)
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var err error
 	customChecks := []healthz.Checker{}
 
@@ -265,9 +270,9 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		return errors.New("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
-	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, s.managedClusterKubeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, s.managedClusterKubeClient, podNamespace, func() {
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
@@ -280,21 +285,22 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		CipherSuites: sdkTLSConfig.CipherSuites,
 	}
 
-	go func() {
-		// Currently ServeHealthProbes uses HTTP so our tlsConfig is not needed, however passing through for
-		// consistency and in case it's ever updated to use HTTPS in the future
-		if err = utils.ServeHealthProbes(":8000", tlsConfig, customChecks...); err != nil {
-			klog.Fatal(err)
-		}
-	}()
-
-	httpserver := &http.Server{
+	healthServer := utils.NewHealthProbeServer(":8000", customChecks...)
+	publicServer := &http.Server{
 		Addr:      fmt.Sprintf(":%d", constant.ServiceProxyPort),
 		TLSConfig: tlsConfig,
 		Handler:   s,
 	}
 
-	return httpserver.ListenAndServeTLS(s.cert, s.key)
+	klog.Infof("starting service proxy HTTPS server on %d and health server on 8000", constant.ServiceProxyPort)
+	return utils.RunHTTPServers(
+		runCtx,
+		s.drain,
+		publicServer,
+		s.cert,
+		s.key,
+		healthServer,
+	)
 }
 
 func (s *serviceProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
@@ -393,6 +399,9 @@ func (s *serviceProxy) closeIdleConnections() {
 }
 
 func (s *serviceProxy) validate() error {
+	if err := s.drain.Validate(); err != nil {
+		return err
+	}
 	if s.cert == "" {
 		return fmt.Errorf("cert is required")
 	}

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -68,6 +68,7 @@ type userServer struct {
 
 	serviceProxyCACertPath string
 	agentInstallNamespace  string
+	drain                  utils.DrainConfig
 
 	addonLister addonlisterv1beta1.ManagedClusterAddOnLister
 }
@@ -89,9 +90,14 @@ func (k *userServer) AddFlags(cmd *cobra.Command) {
 	flags.StringVar(&k.serviceProxyCACertPath, "service-proxy-ca-cert", k.serviceProxyCACertPath, "The path to the CA certificate of the service proxy server")
 
 	flags.StringVar(&k.agentInstallNamespace, "agent-install-namespace", k.agentInstallNamespace, "The namespace of the agent install")
+	k.drain.AddFlags(flags)
 }
 
 func (k *userServer) Validate() error {
+	if err := k.drain.Validate(); err != nil {
+		return err
+	}
+
 	if k.serverCert == "" {
 		return fmt.Errorf("the server-cert is required")
 	}
@@ -231,6 +237,9 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 }
 
 func (k *userServer) Run(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var err error
 
 	klog.Info("begin to run user server")
@@ -239,7 +248,7 @@ func (k *userServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err = k.init(ctx); err != nil {
+	if err = k.init(runCtx); err != nil {
 		return err
 	}
 
@@ -256,9 +265,9 @@ func (k *userServer) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create kube client for TLS watcher: %w", err)
 	}
-	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(ctx, kubeClient, podNamespace, func() {
-		klog.Info("TLS ConfigMap changed, restarting")
-		os.Exit(0)
+	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, kubeClient, podNamespace, func() {
+		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
+		cancel()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start TLS ConfigMap watcher: %w", err)
@@ -276,28 +285,22 @@ func (k *userServer) Run(ctx context.Context) error {
 		CipherSuites: sdkTLSConfig.CipherSuites,
 	}
 
-	go func() {
-		// Currently ServeHealthProbes uses HTTP so our tlsConfig is not needed, however passing through for
-		// consistency and in case it's ever updated to use HTTPS in the future
-		if err = utils.ServeHealthProbes(":8000", tlsConfig, cc.Check); err != nil {
-			klog.Fatal(err)
-		}
-	}()
-
-	klog.Infof("start https server on %d", k.serverPort)
-
-	s := &http.Server{
+	healthServer := utils.NewHealthProbeServer(":8000", cc.Check)
+	publicServer := &http.Server{
 		Addr:      fmt.Sprintf(":%d", k.serverPort),
 		TLSConfig: tlsConfig,
 		Handler:   k,
 	}
 
-	err = s.ListenAndServeTLS(k.serverCert, k.serverKey)
-	if err != nil {
-		return fmt.Errorf("failed to start user proxy server: %w", err)
-	}
-
-	return nil
+	klog.Infof("starting user HTTPS server on %d and health server on 8000", k.serverPort)
+	return utils.RunHTTPServers(
+		runCtx,
+		k.drain,
+		publicServer,
+		k.serverCert,
+		k.serverKey,
+		healthServer,
+	)
 }
 
 // serviceProxyURL is used to generate the URL of the service proxy server.

--- a/pkg/utils/http_server.go
+++ b/pkg/utils/http_server.go
@@ -1,0 +1,169 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+const (
+	DefaultDrainTimeout     = 30 * time.Second
+	DefaultMinDrainDuration = 10 * time.Second
+)
+
+// DrainConfig controls how long active HTTP requests may remain during shutdown.
+// MinDuration is part of, rather than additional to, Timeout.
+type DrainConfig struct {
+	Timeout     time.Duration
+	MinDuration time.Duration
+}
+
+func (c DrainConfig) Validate() error {
+	if c.Timeout < 0 {
+		return fmt.Errorf("drain-timeout must not be negative")
+	}
+	if c.MinDuration < 0 {
+		return fmt.Errorf("min-drain-duration must not be negative")
+	}
+	if c.MinDuration > c.Timeout {
+		return fmt.Errorf("min-drain-duration must not exceed drain-timeout")
+	}
+	return nil
+}
+
+// AddFlags registers the drain flags shared by the proxy server commands.
+func (c *DrainConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.DurationVar(&c.Timeout, "drain-timeout", DefaultDrainTimeout,
+		"Maximum time to drain active HTTP requests during shutdown.")
+	flags.DurationVar(&c.MinDuration, "min-drain-duration", DefaultMinDrainDuration,
+		"Minimum drain duration allowing time for endpoint deprogramming.")
+}
+
+type HealthProbeServer struct {
+	*http.Server
+	ready atomic.Bool
+}
+
+// NewHealthProbeServer creates separate liveness and readiness endpoints.
+// Readiness only represents whether the proxy is accepting new traffic; the
+// existing config checks remain on the liveness endpoint.
+func NewHealthProbeServer(healthProbeBindAddress string, customChecks ...healthz.Checker) *HealthProbeServer {
+	healthServer := &HealthProbeServer{}
+	healthServer.ready.Store(true)
+
+	mux := http.NewServeMux()
+	checks := map[string]healthz.Checker{
+		"healthz-ping": healthz.Ping,
+	}
+	for i, check := range customChecks {
+		checks[fmt.Sprintf("custom-healthz-checker-%d", i)] = check
+	}
+
+	mux.Handle("/healthz", http.StripPrefix("/healthz", &healthz.Handler{Checks: checks}))
+	mux.HandleFunc("/readyz", func(writer http.ResponseWriter, _ *http.Request) {
+		if !healthServer.ready.Load() {
+			http.Error(writer, "draining", http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	})
+	healthServer.Server = &http.Server{
+		Addr:              healthProbeBindAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return healthServer
+}
+
+func (s *HealthProbeServer) SetReady(ready bool) {
+	s.ready.Store(ready)
+}
+
+type httpServerResult struct {
+	health bool
+	err    error
+}
+
+// RunHTTPServers serves until the context is canceled or either server stops.
+// During planned shutdown it first removes the proxy from readiness, waits for
+// endpoint deprogramming, and then drains requests managed by net/http.
+func RunHTTPServers(
+	ctx context.Context,
+	drainConfig DrainConfig,
+	public *http.Server,
+	certFile, keyFile string,
+	health *HealthProbeServer,
+) error {
+	if ctx.Err() != nil {
+		health.SetReady(false)
+		return nil
+	}
+
+	return runHTTPServers(ctx, drainConfig, public, health, func() error {
+		return public.ListenAndServeTLS(certFile, keyFile)
+	})
+}
+
+func runHTTPServers(
+	ctx context.Context,
+	drainConfig DrainConfig,
+	public *http.Server,
+	health *HealthProbeServer,
+	servePublic func() error,
+) error {
+	serverResults := make(chan httpServerResult, 2)
+	go func() {
+		serverResults <- httpServerResult{err: servePublic()}
+	}()
+	go func() {
+		serverResults <- httpServerResult{health: true, err: health.ListenAndServe()}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case result := <-serverResults:
+		return unexpectedServerError(result)
+	}
+
+	health.SetReady(false)
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), drainConfig.Timeout)
+	defer cancelDrain()
+
+	if drainConfig.MinDuration > 0 {
+		timer := time.NewTimer(drainConfig.MinDuration)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case result := <-serverResults:
+			return unexpectedServerError(result)
+		}
+	}
+
+	err := public.Shutdown(drainCtx)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.DeadlineExceeded):
+		klog.Warningf("HTTP request drain timeout %s expired; exiting with active requests", drainConfig.Timeout)
+		return nil
+	default:
+		return fmt.Errorf("drain public proxy HTTP requests: %w", err)
+	}
+}
+
+func unexpectedServerError(result httpServerResult) error {
+	if result.err == nil {
+		return fmt.Errorf("HTTP server stopped unexpectedly")
+	}
+	if result.health {
+		return fmt.Errorf("health probe HTTP server failed: %w", result.err)
+	}
+	return fmt.Errorf("public proxy HTTP server failed: %w", result.err)
+}

--- a/pkg/utils/http_server_test.go
+++ b/pkg/utils/http_server_test.go
@@ -1,0 +1,394 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDrainConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  DrainConfig
+		wantErr bool
+	}{
+		{name: "defaults", config: DrainConfig{Timeout: DefaultDrainTimeout, MinDuration: DefaultMinDrainDuration}},
+		{name: "immediate", config: DrainConfig{}},
+		{name: "negative timeout", config: DrainConfig{Timeout: -time.Second}, wantErr: true},
+		{name: "negative minimum", config: DrainConfig{Timeout: time.Second, MinDuration: -time.Second}, wantErr: true},
+		{name: "minimum exceeds timeout", config: DrainConfig{Timeout: time.Second, MinDuration: 2 * time.Second}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.config.Validate(); (err != nil) != test.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestHealthProbeServerReadiness(t *testing.T) {
+	server := NewHealthProbeServer("127.0.0.1:8000")
+	assertProbeStatus(t, server, "/healthz", http.StatusOK)
+	assertProbeStatus(t, server, "/readyz", http.StatusOK)
+
+	server.SetReady(false)
+	assertProbeStatus(t, server, "/readyz", http.StatusServiceUnavailable)
+	assertProbeStatus(t, server, "/healthz", http.StatusOK)
+}
+
+func TestRunHTTPServersWaitsForMinimumDrainDuration(t *testing.T) {
+	servers := newTestServers(t, http.NotFoundHandler())
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := runTestHTTPServers(ctx,
+		DrainConfig{Timeout: time.Second, MinDuration: 100 * time.Millisecond}, servers, servers.serve)
+	waitForPublicServer(t, http.DefaultClient, servers.url())
+
+	startedDrain := time.Now()
+	cancel()
+	eventuallyProbeStatus(t, servers.health, "/readyz", http.StatusServiceUnavailable)
+
+	connection, err := net.DialTimeout("tcp", servers.listener.Addr().String(), 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("public listener closed during minimum drain duration: %v", err)
+	}
+	_ = connection.Close()
+
+	if err := <-runResult; err != nil {
+		t.Fatalf("drain returned an error: %v", err)
+	}
+	if elapsed := time.Since(startedDrain); elapsed < 90*time.Millisecond {
+		t.Fatalf("server stopped before minimum drain duration: %v", elapsed)
+	}
+	if connection, err := net.DialTimeout("tcp", servers.listener.Addr().String(), 50*time.Millisecond); err == nil {
+		_ = connection.Close()
+		t.Fatal("public listener remained open after drain")
+	}
+}
+
+func TestRunHTTPServersDrainsHTTP2Request(t *testing.T) {
+	requestStarted := make(chan int, 1)
+	releaseRequest := make(chan struct{})
+	servers := newTestServers(t, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestStarted <- request.ProtoMajor
+		<-releaseRequest
+		_, _ = io.WriteString(writer, "drained")
+	}))
+	tlsConfig, transport := testHTTP2Config(t)
+	servers.public.TLSConfig = tlsConfig
+	t.Cleanup(transport.CloseIdleConnections)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := runTestHTTPServers(ctx,
+		DrainConfig{Timeout: time.Second, MinDuration: 20 * time.Millisecond}, servers,
+		func() error { return servers.public.ServeTLS(servers.listener, "", "") })
+	responseResult := requestBody(&http.Client{Transport: transport, Timeout: time.Second},
+		"https://"+servers.listener.Addr().String())
+
+	if protocol := <-requestStarted; protocol != 2 {
+		t.Fatalf("request protocol = HTTP/%d, want HTTP/2", protocol)
+	}
+	cancel()
+	select {
+	case err := <-runResult:
+		t.Fatalf("server returned before active request drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseRequest)
+	bodyResult := <-responseResult
+	if bodyResult.err != nil {
+		t.Fatalf("request failed during drain: %v", bodyResult.err)
+	}
+	if bodyResult.body != "drained" {
+		t.Fatalf("response body = %q, want drained", bodyResult.body)
+	}
+	if err := <-runResult; err != nil {
+		t.Fatalf("drain returned an error: %v", err)
+	}
+}
+
+func TestRunHTTPServersClosesIdleKeepAliveConnection(t *testing.T) {
+	servers := newTestServers(t, http.NotFoundHandler())
+	client := &http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := runTestHTTPServers(ctx,
+		DrainConfig{Timeout: time.Second, MinDuration: 20 * time.Millisecond}, servers, servers.serve)
+	waitForPublicServer(t, client, servers.url())
+
+	reused := false
+	request, err := http.NewRequest(http.MethodGet, servers.url(), nil)
+	if err != nil {
+		t.Fatalf("create keep-alive request: %v", err)
+	}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			reused = info.Reused
+		},
+	}))
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("make keep-alive request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if !reused {
+		t.Fatal("test connection was not reused before becoming idle")
+	}
+
+	cancel()
+	select {
+	case err := <-runResult:
+		if err != nil {
+			t.Fatalf("drain returned an error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("idle keep-alive connection delayed shutdown")
+	}
+}
+
+func TestRunHTTPServersDoesNotWaitForHijackedConnection(t *testing.T) {
+	hijacked := make(chan struct{})
+	handlerDone := make(chan struct{})
+	servers := newTestServers(t, hijackedConnectionHandler(hijacked, handlerDone))
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := runTestHTTPServers(ctx,
+		DrainConfig{Timeout: time.Second, MinDuration: 20 * time.Millisecond}, servers, servers.serve)
+	connection := openHijackedConnection(t, servers.listener.Addr().String())
+	<-hijacked
+
+	cancel()
+	select {
+	case err := <-runResult:
+		if err != nil {
+			t.Fatalf("drain returned an error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("server waited for hijacked connection")
+	}
+	select {
+	case <-handlerDone:
+		t.Fatal("hijacked connection closed before process exit")
+	default:
+	}
+
+	if err := connection.Close(); err != nil {
+		t.Fatalf("close hijacked client connection: %v", err)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("hijacked handler did not finish after client close")
+	}
+}
+
+func TestRunHTTPServersBoundsActiveRequestDrain(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	servers := newTestServers(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		_, _ = io.WriteString(writer, "finished")
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	runResult := runTestHTTPServers(ctx,
+		DrainConfig{Timeout: 200 * time.Millisecond, MinDuration: 50 * time.Millisecond}, servers, servers.serve)
+	responseResult := requestBody(&http.Client{Timeout: time.Second}, servers.url())
+	<-requestStarted
+
+	startedDrain := time.Now()
+	cancel()
+	select {
+	case err := <-runResult:
+		if err != nil {
+			t.Fatalf("planned timeout returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("drain timeout did not bound server termination")
+	}
+	elapsed := time.Since(startedDrain)
+	if elapsed < 180*time.Millisecond {
+		t.Fatalf("server stopped before drain deadline: %v", elapsed)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("minimum duration was added to the overall timeout: %v", elapsed)
+	}
+
+	close(releaseRequest)
+	if result := <-responseResult; result.err != nil {
+		t.Fatalf("active request failed after drain timeout: %v", result.err)
+	}
+}
+
+func TestRunHTTPServersPropagatesHealthServerFailure(t *testing.T) {
+	servers := newTestServers(t, http.NotFoundHandler())
+	servers.health = NewHealthProbeServer("invalid address")
+
+	err := <-runTestHTTPServers(context.Background(), DrainConfig{Timeout: time.Second}, servers, servers.serve)
+	if err == nil || !strings.Contains(err.Error(), "health probe HTTP server failed") {
+		t.Fatalf("expected health server failure, got %v", err)
+	}
+}
+
+type testServers struct {
+	public   *http.Server
+	listener net.Listener
+	health   *HealthProbeServer
+}
+
+func newTestServers(t *testing.T, handler http.Handler) *testServers {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for test proxy server: %v", err)
+	}
+
+	servers := &testServers{
+		public:   &http.Server{Addr: listener.Addr().String(), Handler: handler},
+		listener: listener,
+		health:   NewHealthProbeServer("127.0.0.1:0"),
+	}
+	t.Cleanup(func() {
+		_ = servers.public.Close()
+		_ = servers.health.Close()
+		_ = servers.listener.Close()
+	})
+	return servers
+}
+
+func (s *testServers) serve() error {
+	return s.public.Serve(s.listener)
+}
+
+func (s *testServers) url() string {
+	return "http://" + s.listener.Addr().String()
+}
+
+func runTestHTTPServers(
+	ctx context.Context,
+	config DrainConfig,
+	servers *testServers,
+	servePublic func() error,
+) <-chan error {
+	result := make(chan error, 1)
+	go func() {
+		result <- runHTTPServers(ctx, config, servers.public, servers.health, servePublic)
+	}()
+	return result
+}
+
+func waitForPublicServer(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	if result := <-requestBody(client, url); result.err != nil {
+		t.Fatalf("wait for public server: %v", result.err)
+	}
+}
+
+type bodyResult struct {
+	body string
+	err  error
+}
+
+func requestBody(client *http.Client, url string) <-chan bodyResult {
+	result := make(chan bodyResult, 1)
+	go func() {
+		response, err := client.Get(url)
+		if err != nil {
+			result <- bodyResult{err: err}
+			return
+		}
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		result <- bodyResult{body: string(body), err: err}
+	}()
+	return result
+}
+
+func assertProbeStatus(t *testing.T, server *HealthProbeServer, path string, status int) {
+	t.Helper()
+	response := httptest.NewRecorder()
+	server.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+	if response.Code != status {
+		t.Fatalf("%s status = %d, want %d", path, response.Code, status)
+	}
+}
+
+func eventuallyProbeStatus(t *testing.T, server *HealthProbeServer, path string, status int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		response := httptest.NewRecorder()
+		server.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code == status {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("%s did not reach status %d", path, status)
+}
+
+func testHTTP2Config(t *testing.T) (*tls.Config, *http.Transport) {
+	t.Helper()
+	testServer := httptest.NewUnstartedServer(http.NotFoundHandler())
+	testServer.EnableHTTP2 = true
+	testServer.StartTLS()
+	tlsConfig := testServer.TLS.Clone()
+	transport := testServer.Client().Transport.(*http.Transport).Clone()
+	testServer.Close()
+	return tlsConfig, transport
+}
+
+func hijackedConnectionHandler(hijacked, done chan<- struct{}) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := writer.(http.Hijacker)
+		if !ok {
+			return
+		}
+		connection, buffered, err := hijacker.Hijack()
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = connection.Close()
+			close(done)
+		}()
+
+		_, _ = buffered.WriteString("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n")
+		_ = buffered.Flush()
+		close(hijacked)
+		_, _ = io.Copy(io.Discard, connection)
+	})
+}
+
+func openHijackedConnection(t *testing.T, address string) net.Conn {
+	t.Helper()
+	connection, err := net.DialTimeout("tcp", address, time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy server: %v", err)
+	}
+	if _, err := io.WriteString(connection,
+		"GET / HTTP/1.1\r\nHost: "+address+"\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"); err != nil {
+		_ = connection.Close()
+		t.Fatalf("write upgrade request: %v", err)
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(connection), nil)
+	if err != nil {
+		_ = connection.Close()
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		_ = connection.Close()
+		t.Fatalf("unexpected upgrade response status: %d", response.StatusCode)
+	}
+	return connection
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,16 +1,12 @@
 package utils
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
 const (
@@ -156,28 +152,4 @@ func GetProxyType(reqURI string) int {
 		return ProxyTypeService
 	}
 	return ProxyTypeKubeAPIServer
-}
-
-// ServeHealthProbes serves health probes and configchecker.
-func ServeHealthProbes(healthProbeBindAddress string, tlsConfig *tls.Config, customChecks ...healthz.Checker) error {
-	mux := http.NewServeMux()
-
-	checks := map[string]healthz.Checker{
-		"healthz-ping": healthz.Ping,
-	}
-
-	for i, check := range customChecks {
-		checks[fmt.Sprintf("custom-healthz-checker-%d", i)] = check
-	}
-
-	mux.Handle("/healthz", http.StripPrefix("/healthz", &healthz.Handler{Checks: checks}))
-	server := http.Server{
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-		Addr:              healthProbeBindAddress,
-		// TLS config is currently unused, as below we are using ListenAndServe() which will serve HTTP
-		TLSConfig: tlsConfig,
-	}
-	klog.Infof("heath probes server is running...")
-	return server.ListenAndServe()
 }


### PR DESCRIPTION
The user-server and service-proxy currently stop without giving active HTTP requests time to finish when they receive SIGTERM or reload their TLS configuration. This can interrupt proxy traffic during rollouts, node drains, preemption, or a TLS profile change.

This change adds a readiness-first shutdown sequence around the public HTTP servers. Each server reports itself unready, keeps its listener available for a short endpoint propagation window, and then uses Go's standard [`http.Server.Shutdown`](https://pkg.go.dev/net/http#Server.Shutdown) to close the listener and idle connections while active HTTP requests finish within the drain timeout.

Connections hijacked from `net/http`, including WebSocket- and SPDY-based exec, attach, and port-forward sessions, are intentionally not included in the drain. Waiting could allow some of those sessions to close naturally, but cluster-proxy cannot send a common shutdown notification or transfer them to another Pod. They are disconnected when the process exits. Keeping this boundary lets the implementation use the standard HTTP lifecycle without a custom TCP connection tracker.

On a TLS configuration change, the affected container follows the same shutdown sequence and exits. The kubelet restarts that container in the existing Pod so the new TLS settings are loaded.

## Shutdown flow

```mermaid
sequenceDiagram
    participant S as Shutdown trigger
    participant P as Proxy process
    participant K as Kubernetes
    participant C as Existing clients

    S->>P: SIGTERM or TLS configuration change
    P->>P: Mark /readyz unready
    K->>P: Probe /readyz
    P-->>K: 503 Service Unavailable
    K->>K: Remove the Pod from endpoints

    Note over P,K: Keep the listener open for the 10s propagation window

    P->>P: Call http.Server.Shutdown
    P->>P: Close the listener and idle HTTP connections
    P-->>C: Allow active HTTP requests to finish

    alt Active HTTP requests finish
        P->>P: Exit
    else 30s drain timeout expires
        P->>P: Exit with active requests
    end

    Note over P,C: Hijacked upgrade connections are not awaited and disconnect on exit
```

## What changed

- Add separate `/healthz` and `/readyz` endpoints.
- Drain HTTP requests with `http.Server.Shutdown` after an endpoint propagation delay.
- Replace `os.Exit(0)` on TLS changes with context cancellation so the same shutdown path runs first.
- Route process signals through the root command context.
- Use controller-runtime's default graceful shutdown for the controllers command.
- Set the Pod termination grace period to 40 seconds.

The user-server and service-proxy expose:

- `--drain-timeout` (default `30s`)
- `--min-drain-duration` (default `10s`)

The minimum duration is included in the overall drain timeout. Service-proxy overrides can be passed through `ManagedProxyConfiguration.spec.proxyAgent.additionalServiceProxyArgs`.
