### PR TITLE
:sparkles: set a timeout for proxy request headers

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -286,11 +286,7 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 	}
 
 	healthServer := utils.NewHealthProbeServer(":8000", customChecks...)
-	publicServer := &http.Server{
-		Addr:      fmt.Sprintf(":%d", constant.ServiceProxyPort),
-		TLSConfig: tlsConfig,
-		Handler:   s,
-	}
+	publicServer := utils.NewProxyHTTPServer(fmt.Sprintf(":%d", constant.ServiceProxyPort), tlsConfig, s)
 
 	klog.Infof("starting service proxy HTTPS server on %d and health server on 8000", constant.ServiceProxyPort)
 	return utils.RunHTTPServers(

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -286,11 +286,7 @@ func (k *userServer) Run(ctx context.Context) error {
 	}
 
 	healthServer := utils.NewHealthProbeServer(":8000", cc.Check)
-	publicServer := &http.Server{
-		Addr:      fmt.Sprintf(":%d", k.serverPort),
-		TLSConfig: tlsConfig,
-		Handler:   k,
-	}
+	publicServer := utils.NewProxyHTTPServer(fmt.Sprintf(":%d", k.serverPort), tlsConfig, k)
 
 	klog.Infof("starting user HTTPS server on %d and health server on 8000", k.serverPort)
 	return utils.RunHTTPServers(

--- a/pkg/utils/http_server.go
+++ b/pkg/utils/http_server.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,7 +17,18 @@ import (
 const (
 	DefaultDrainTimeout     = 30 * time.Second
 	DefaultMinDrainDuration = 10 * time.Second
+	proxyReadHeaderTimeout  = 32 * time.Second
 )
+
+// NewProxyHTTPServer creates an HTTP server for proxy traffic.
+func NewProxyHTTPServer(address string, tlsConfig *tls.Config, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              address,
+		TLSConfig:         tlsConfig,
+		Handler:           handler,
+		ReadHeaderTimeout: proxyReadHeaderTimeout,
+	}
+}
 
 // DrainConfig controls how long active HTTP requests may remain during shutdown.
 // MinDuration is part of, rather than additional to, Timeout.


### PR DESCRIPTION
Proxy listeners currently allow clients unlimited time to send request headers. Set a 32-second header timeout, matching the [Kubernetes API server's secure serving default](https://github.com/kubernetes/kubernetes/blob/v1.36.3/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L168-L176).
