### PR TITLE
✨ Initialize OIDC authentication from configuration events

### DIFF
--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -751,27 +751,18 @@ func TestNewAgentAddon(t *testing.T) {
 						"--oidc-groups-claim=groups",
 						"--oidc-groups-prefix=oidc:",
 						"--oidc-reserved-name-prefixes=system:,dev:",
-						"--oidc-ca-file=/oidc-ca/ca.crt",
+						"--oidc-ca-configmap=dex-ca",
 						"--oidc-signing-algs=RS256,ES256",
 						"--oidc-required-claim=hd=example.com",
 						"--oidc-required-claim=tenant=tenant-id",
 					})
-
-					assert.Contains(t, serviceProxy.VolumeMounts, corev1.VolumeMount{
-						Name:      "oidc-ca",
-						MountPath: "/oidc-ca",
-						ReadOnly:  true,
-					})
+					assert.False(t, slices.ContainsFunc(serviceProxy.VolumeMounts, func(mount corev1.VolumeMount) bool {
+						return mount.Name == "oidc-ca"
+					}))
 				}
-				assert.Contains(t, agentDeploy.Spec.Template.Spec.Volumes, corev1.Volume{
-					Name: "oidc-ca",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "dex-ca"},
-							Optional:             ptr.To(true),
-						},
-					},
-				})
+				assert.False(t, slices.ContainsFunc(agentDeploy.Spec.Template.Spec.Volumes, func(volume corev1.Volume) bool {
+					return volume.Name == "oidc-ca"
+				}))
 			},
 		},
 		{

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-deployment.yaml
@@ -205,7 +205,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- if .Values.oidcCAConfigMap }}
-            - --oidc-ca-file=/oidc-ca/ca.crt
+            - {{ printf "--oidc-ca-configmap=%s" .Values.oidcCAConfigMap | quote }}
             {{- end }}
           {{- end }}
             {{- range .Values.additionalServiceProxyArgs }}
@@ -242,11 +242,6 @@ spec:
               mountPath: /additional-service-ca
               readOnly: true
             {{- end }}
-            {{- if and .Values.oidcIssuerURL .Values.oidcCAConfigMap }}
-            - name: oidc-ca
-              mountPath: /oidc-ca
-              readOnly: true
-            {{- end }}
             - name: service-proxy-server-cert
               mountPath: /server-cert
               readOnly: true
@@ -271,12 +266,6 @@ spec:
         - name: additional-service-ca
           configMap:
             name: {{ .Values.additionalServiceCAConfigMap }}
-            optional: true
-        {{- end }}
-        {{- if and .Values.oidcIssuerURL .Values.oidcCAConfigMap }}
-        - name: oidc-ca
-          configMap:
-            name: {{ .Values.oidcCAConfigMap }}
             optional: true
         {{- end }}
         - name: service-proxy-server-cert

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.schema.json
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.schema.json
@@ -56,7 +56,7 @@
       "type": "object"
     },
     "oidcCAConfigMap": {
-      "description": "Managed cluster ConfigMap containing the private issuer CA in the ca.crt key. Empty uses system root CAs.",
+      "description": "Managed cluster ConfigMap watched for the private issuer CA in the ca.crt key. Empty uses system root CAs.",
       "type": "string"
     },
     "oidcClientID": {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -81,7 +81,7 @@ oidcGroupsPrefix: ""
 # -- Username and group prefixes that OIDC claims must not use. Customized variables use a comma-separated string.
 oidcReservedNamePrefixes:
   - "system:"
-# -- Managed cluster ConfigMap containing the private issuer CA in the ca.crt key. Empty uses system root CAs.
+# -- Managed cluster ConfigMap watched for the private issuer CA in the ca.crt key. Empty uses system root CAs.
 oidcCAConfigMap: ""
 # @schema oneOf:[{type: array, items: {type: string}}, {type: string}]
 # -- Allowed JOSE asymmetric signing algorithms. Empty keeps the service-proxy default of RS256.

--- a/pkg/serviceproxy/auth_provider.go
+++ b/pkg/serviceproxy/auth_provider.go
@@ -51,6 +51,7 @@ type authProviderFactoryLogger interface {
 
 type authProviderDependencies struct {
 	managedClusterKubeClient kubernetes.Interface
+	podNamespace             string
 	kubeClientQPS            float32
 	kubeClientBurst          int
 	tokenReviewCacheTTL      time.Duration
@@ -64,9 +65,10 @@ func defaultAuthProviderFactories() []authProviderFactory {
 	}
 }
 
-func (s *serviceProxy) authProviderDependencies() authProviderDependencies {
+func (s *serviceProxy) authProviderDependencies(podNamespace string) authProviderDependencies {
 	return authProviderDependencies{
 		managedClusterKubeClient: s.managedClusterKubeClient,
+		podNamespace:             podNamespace,
 		kubeClientQPS:            s.kubeClientQPS,
 		kubeClientBurst:          s.kubeClientBurst,
 		tokenReviewCacheTTL:      s.tokenReviewCacheTTL,
@@ -74,7 +76,7 @@ func (s *serviceProxy) authProviderDependencies() authProviderDependencies {
 	}
 }
 
-func (s *serviceProxy) initializeAuthProviders(ctx context.Context) error {
+func (s *serviceProxy) initializeAuthProviders(ctx context.Context, podNamespace string) error {
 	enabledFactories := make([]authProviderFactory, 0, len(s.authProviderFactories))
 
 	for _, factory := range s.authProviderFactories {
@@ -88,7 +90,7 @@ func (s *serviceProxy) initializeAuthProviders(ctx context.Context) error {
 		return nil
 	}
 
-	dependencies := s.authProviderDependencies()
+	dependencies := s.authProviderDependencies(podNamespace)
 	providers := make([]authProvider, 0, len(enabledFactories)+1)
 	providers = append(providers, newManagedClusterAuthProvider(dependencies))
 

--- a/pkg/serviceproxy/auth_provider_test.go
+++ b/pkg/serviceproxy/auth_provider_test.go
@@ -142,7 +142,7 @@ func TestInitializeAuthProvidersUsesEnabledFactoriesInRegistryOrder(t *testing.T
 		},
 	}
 
-	if err := s.initializeAuthProviders(t.Context()); err != nil {
+	if err := s.initializeAuthProviders(t.Context(), "addon"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func TestInitializeAuthProvidersDoesNotPublishPartialFactoryResults(t *testing.T
 		authProviders: []authProvider{existing},
 	}
 
-	if err := s.initializeAuthProviders(t.Context()); !errors.Is(err, buildErr) {
+	if err := s.initializeAuthProviders(t.Context(), "addon"); !errors.Is(err, buildErr) {
 		t.Fatalf("error = %v, want %v", err, buildErr)
 	}
 	if len(s.authProviders) != 1 || s.authProviders[0] != existing {
@@ -228,12 +228,10 @@ func TestInitializeAuthProviders(t *testing.T) {
 				hubFactory.kubeConfig = writeTestHubKubeConfig(t)
 			}
 			if tt.enableOIDC {
-				oidcFactory.options = oidcOptions{
-					issuerURL: "https://issuer.example.com",
-					clientID:  "cluster-proxy",
-				}
+				oidcFactory.options.issuerURL = "https://issuer.example.com"
+				oidcFactory.options.clientID = "cluster-proxy"
 			}
-			if err := s.initializeAuthProviders(t.Context()); err != nil {
+			if err := s.initializeAuthProviders(t.Context(), "addon"); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -259,7 +257,7 @@ func TestInitializeAuthProvidersFailureDoesNotPublishPartialProviders(t *testing
 		},
 	}
 
-	if err := s.initializeAuthProviders(t.Context()); err == nil {
+	if err := s.initializeAuthProviders(t.Context(), "addon"); err == nil {
 		t.Fatal("expected hub kubeconfig error")
 	}
 	if len(s.authProviders) != 0 {

--- a/pkg/serviceproxy/oidc_auth_provider.go
+++ b/pkg/serviceproxy/oidc_auth_provider.go
@@ -2,6 +2,7 @@ package serviceproxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/spf13/pflag"
@@ -54,7 +55,7 @@ func (f *oidcAuthProviderFactory) addFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.options.groupsClaim, "oidc-groups-claim", f.options.groupsClaim, "The OIDC claim to use as the user's groups. The claim value is expected to be a string or an array of strings.")
 	flags.StringVar(&f.options.groupsPrefix, "oidc-groups-prefix", f.options.groupsPrefix, "The prefix prepended to group claims to prevent clashes with existing groups.")
 	flags.StringSliceVar(&f.options.reservedNamePrefixes, "oidc-reserved-name-prefixes", f.options.reservedNamePrefixes, "Comma-separated list of prefixes that authenticated OIDC usernames and groups must not use. The list replaces the default; set an empty value to disable the check.")
-	flags.StringVar(&f.options.caFile, "oidc-ca-file", f.options.caFile, "The path to a CA bundle used to verify the OIDC issuer's serving certificate. Defaults to the host's root CAs.")
+	flags.StringVar(&f.options.caConfigMap, "oidc-ca-configmap", f.options.caConfigMap, "The name of a ConfigMap in POD_NAMESPACE containing the OIDC issuer CA under ca.crt. The ConfigMap is watched and reconciled when it changes. Defaults to the host's root CAs.")
 	flags.StringSliceVar(&f.options.signingAlgs, "oidc-signing-algs", f.options.signingAlgs, "Comma-separated list of allowed JOSE asymmetric signing algorithms for OIDC tokens.")
 	flags.Var(cliflag.NewMapStringStringNoSplit(&f.options.requiredClaims), "oidc-required-claim", "A key=value pair that must be present in the OIDC ID token. Repeat this flag to require multiple claims.")
 }
@@ -72,8 +73,24 @@ func (*oidcAuthProviderFactory) configFiles() []string {
 }
 
 func (f *oidcAuthProviderFactory) build(ctx context.Context, dependencies authProviderDependencies) (authProvider, error) {
+	authn, err := newOIDCAuthenticator(ctx, f.options)
+	if err != nil {
+		return nil, err
+	}
+	if f.options.caConfigMap != "" {
+		if err := startOIDCCAConfigMapController(
+			ctx,
+			dependencies.managedClusterKubeClient,
+			dependencies.podNamespace,
+			f.options.caConfigMap,
+			authn,
+		); err != nil {
+			return nil, fmt.Errorf("failed to start OIDC CA ConfigMap controller: %w", err)
+		}
+	}
+
 	return &oidcAuthProvider{
-		Token:           newOIDCAuthenticator(ctx, f.options),
+		Token:           authn,
 		impersonateUser: dependencies.impersonateUser,
 	}, nil
 }

--- a/pkg/serviceproxy/oidc_auth_provider_test.go
+++ b/pkg/serviceproxy/oidc_auth_provider_test.go
@@ -8,10 +8,64 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestOIDCAuthProviderFactoryBuildsConfigMapBackedProvider(t *testing.T) {
+	const (
+		namespace = "addon"
+		name      = "oidc-ca"
+	)
+	issuer := newFakeIssuer(t)
+	factory := &oidcAuthProviderFactory{options: issuer.defaultOpts()}
+	client := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       map[string]string{oidcCAConfigMapKey: string(issuer.caPEM)},
+	})
+
+	provider, err := factory.build(t.Context(), authProviderDependencies{
+		managedClusterKubeClient: client,
+		podNamespace:             namespace,
+	})
+	if err != nil {
+		t.Fatalf("build OIDC provider: %v", err)
+	}
+
+	token := issuer.signToken(t, issuer.claims(nil))
+	response, ok, err := authenticateUntilSettled(t, provider, token, 5*time.Second)
+	if err != nil || !ok {
+		t.Fatalf("expected authentication success, got ok=%v err=%v", ok, err)
+	}
+	if want := issuer.server.URL + "#test-user"; response.User.GetName() != want {
+		t.Fatalf("expected username %q, got %q", want, response.User.GetName())
+	}
+}
+
+func TestOIDCAuthProviderFactoryDoesNotBuildWhenControllerCannotSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	factory := newOIDCAuthProviderFactory()
+	factory.options.issuerURL = "https://issuer.example.com"
+	factory.options.clientID = "cluster-proxy"
+	factory.options.caConfigMap = "oidc-ca"
+
+	provider, err := factory.build(ctx, authProviderDependencies{
+		managedClusterKubeClient: fake.NewSimpleClientset(),
+		podNamespace:             "addon",
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to sync OIDC CA ConfigMap informer") {
+		t.Fatalf("expected controller sync error, got provider=%v err=%v", provider, err)
+	}
+	if provider != nil {
+		t.Fatalf("expected no provider after controller startup failure, got %v", provider)
+	}
+}
 
 func TestProcessAuthentication_OIDCToken(t *testing.T) {
 	s := &serviceProxy{

--- a/pkg/serviceproxy/oidc_authenticator.go
+++ b/pkg/serviceproxy/oidc_authenticator.go
@@ -2,7 +2,9 @@ package serviceproxy
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -31,24 +33,54 @@ type oidcOptions struct {
 	usernamePrefix       string
 	groupsClaim          string
 	groupsPrefix         string
-	caFile               string
+	caConfigMap          string
 	signingAlgs          []string
 	requiredClaims       map[string]string
 	reservedNamePrefixes []string
 }
 
-// oidcAuthenticator lazily creates Kubernetes' OIDC authenticator on first use,
-// so an issuer or CA file that is not ready at pod startup does not fail startup.
+// An oidcDelegateFactory returns a delegate and a cleanup function that
+// releases its transport resources; a failed factory has already released them.
+type oidcDelegateFactory func(
+	context.Context,
+	[]byte,
+) (oidcauthenticator.AuthenticatorTokenWithHealthCheck, func(), error)
+
+// oidcAuthenticator atomically exposes the delegate produced for the latest
+// observed OIDC CA configuration. Reconciliation, rather than request traffic,
+// owns delegate initialization and replacement.
 type oidcAuthenticator struct {
 	lifecycleCtx context.Context
 	opts         oidcOptions
 
-	mu       sync.Mutex
-	delegate oidcauthenticator.AuthenticatorTokenWithHealthCheck
+	reconcileMu           sync.Mutex
+	observedConfiguration string
+	newDelegate           oidcDelegateFactory
+
+	mu                  sync.RWMutex
+	delegate            oidcauthenticator.AuthenticatorTokenWithHealthCheck
+	delegateCancel      context.CancelFunc
+	initializationError error
 }
 
-func newOIDCAuthenticator(lifecycleCtx context.Context, opts oidcOptions) *oidcAuthenticator {
-	return &oidcAuthenticator{lifecycleCtx: lifecycleCtx, opts: opts}
+func newOIDCAuthenticator(lifecycleCtx context.Context, opts oidcOptions) (*oidcAuthenticator, error) {
+	a := &oidcAuthenticator{
+		lifecycleCtx:        lifecycleCtx,
+		opts:                opts,
+		initializationError: errors.New("oidc authenticator is not initialized"),
+	}
+	a.newDelegate = a.buildDelegate
+
+	// ConfigMap-backed CA data is initialized by the informer controller after
+	// its cache has synced. System-root configurations can start discovery now.
+	if opts.caConfigMap != "" {
+		return a, nil
+	}
+
+	if _, err := a.reconcileCABundle("system-roots", nil); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 // effectiveUsernamePrefix implements the legacy kube-apiserver flag behavior:
@@ -120,7 +152,6 @@ func validateOIDCOptions(opts oidcOptions) error {
 	if opts.issuerURL == "" {
 		return nil
 	}
-
 	// an empty prefix matches every name and would silently reject all tokens
 	if slices.Contains(opts.reservedNamePrefixes, "") {
 		return fmt.Errorf("--oidc-reserved-name-prefixes must not contain an empty prefix")
@@ -144,46 +175,112 @@ func validateOIDCOptions(opts oidcOptions) error {
 	return nil
 }
 
-func (a *oidcAuthenticator) getDelegate() (oidcauthenticator.AuthenticatorTokenWithHealthCheck, error) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	if a.delegate != nil {
-		return a.delegate, nil
-	}
-
+func (a *oidcAuthenticator) buildDelegate(
+	lifecycleCtx context.Context,
+	caBundle []byte,
+) (oidcauthenticator.AuthenticatorTokenWithHealthCheck, func(), error) {
 	transport := utilnet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 	})
-	if a.opts.caFile != "" {
-		pool, err := certutil.NewPool(a.opts.caFile)
+	if caBundle != nil {
+		pool, err := certutil.NewPoolFromBytes(caBundle)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read oidc CA file: %v", err)
+			return nil, nil, fmt.Errorf("failed to load oidc CA bundle: %w", err)
 		}
 		transport.TLSClientConfig.RootCAs = pool
 	}
 
-	delegate, err := oidcauthenticator.New(a.lifecycleCtx, oidcauthenticator.Options{
+	delegate, err := oidcauthenticator.New(lifecycleCtx, oidcauthenticator.Options{
 		Client:               &http.Client{Timeout: oidcHTTPTimeout, Transport: transport},
 		SupportedSigningAlgs: a.opts.signingAlgs,
 		JWTAuthenticator:     buildJWTAuthenticatorConfig(a.opts),
 		APIServerID:          "cluster-proxy-service-proxy",
 	})
 	if err != nil {
-		return nil, err
+		transport.CloseIdleConnections()
+		return nil, nil, err
+	}
+	return delegate, transport.CloseIdleConnections, nil
+}
+
+func caConfigurationKey(source string, caBundle []byte) string {
+	sum := sha256.Sum256(caBundle)
+	return fmt.Sprintf("%s:%x", source, sum)
+}
+
+// reconcileCABundle applies one observed CA configuration exactly once. It
+// disables the old delegate before constructing the replacement so an invalid
+// security configuration fails closed.
+func (a *oidcAuthenticator) reconcileCABundle(configurationKey string, caBundle []byte) (bool, error) {
+	a.reconcileMu.Lock()
+	defer a.reconcileMu.Unlock()
+
+	if a.observedConfiguration == configurationKey {
+		return false, nil
+	}
+	a.observedConfiguration = configurationKey
+	a.replaceDelegate(nil, nil, errors.New("oidc authenticator is initializing"))
+
+	delegateCtx, cancel := context.WithCancel(a.lifecycleCtx)
+	delegate, cleanup, err := a.newDelegate(delegateCtx, caBundle)
+	if err != nil {
+		cancel()
+		initializationError := fmt.Errorf("failed to initialize OIDC authenticator: %w", err)
+		a.replaceDelegate(nil, nil, initializationError)
+		return true, initializationError
 	}
 
+	a.replaceDelegate(delegate, func() {
+		cancel()
+		if cleanup != nil {
+			cleanup()
+		}
+	}, nil)
+	return true, nil
+}
+
+// markUnavailable records a desired configuration that cannot produce an
+// authenticator. Repeated informer events for the same state are no-ops.
+func (a *oidcAuthenticator) markUnavailable(configurationKey string, err error) bool {
+	a.reconcileMu.Lock()
+	defer a.reconcileMu.Unlock()
+
+	if a.observedConfiguration == configurationKey {
+		return false
+	}
+	a.observedConfiguration = configurationKey
+	a.replaceDelegate(nil, nil, err)
+	return true
+}
+
+func (a *oidcAuthenticator) replaceDelegate(
+	delegate oidcauthenticator.AuthenticatorTokenWithHealthCheck,
+	cancel context.CancelFunc,
+	initializationError error,
+) {
+	a.mu.Lock()
+	oldCancel := a.delegateCancel
 	a.delegate = delegate
-	return delegate, nil
+	a.delegateCancel = cancel
+	a.initializationError = initializationError
+	a.mu.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+	}
 }
 
 // AuthenticateToken delegates OIDC verification and claim mapping to the
 // Kubernetes authenticator, reporting provider health failures as
 // infrastructure errors and token failures as ErrTokenNotAuthenticated.
 func (a *oidcAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-	delegate, err := a.getDelegate()
-	if err != nil {
-		return nil, false, err
+	a.mu.RLock()
+	delegate := a.delegate
+	initializationError := a.initializationError
+	a.mu.RUnlock()
+
+	if delegate == nil {
+		return nil, false, initializationError
 	}
 
 	// Kubernetes stores the verifier before clearing the health error. Snapshot

--- a/pkg/serviceproxy/oidc_authenticator_test.go
+++ b/pkg/serviceproxy/oidc_authenticator_test.go
@@ -10,8 +10,6 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -37,7 +35,6 @@ type fakeIssuer struct {
 	server         *httptest.Server
 	key            *rsa.PrivateKey
 	caPEM          []byte
-	caFile         string
 	discoveryTried atomic.Bool
 	failDiscovery  atomic.Bool
 }
@@ -85,13 +82,27 @@ func newFakeIssuer(t *testing.T) *fakeIssuer {
 
 	f.server = httptest.NewTLSServer(handler)
 	f.caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: f.server.Certificate().Raw})
-	f.caFile = filepath.Join(t.TempDir(), "ca.crt")
-	if err := os.WriteFile(f.caFile, f.caPEM, 0600); err != nil {
-		t.Fatalf("failed to write fake issuer CA file: %v", err)
-	}
 	t.Cleanup(f.server.Close)
 	oidcServer.SetIssuer(f.server.URL)
 	return f
+}
+
+func mustNewOIDCAuthenticator(t *testing.T, opts oidcOptions) *oidcAuthenticator {
+	t.Helper()
+	authn, err := newOIDCAuthenticator(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("failed to initialize OIDC authenticator: %v", err)
+	}
+	return authn
+}
+
+func (f *fakeIssuer) newAuthenticator(t *testing.T, opts oidcOptions) *oidcAuthenticator {
+	t.Helper()
+	authn := mustNewOIDCAuthenticator(t, opts)
+	if _, err := authn.reconcileCABundle(caConfigurationKey("test", f.caPEM), f.caPEM); err != nil {
+		t.Fatalf("failed to reconcile fake issuer CA: %v", err)
+	}
+	return authn
 }
 
 func authenticateUntilSettled(t *testing.T, authn authenticator.Token, token string, timeout time.Duration) (*authenticator.Response, bool, error) {
@@ -116,7 +127,7 @@ func (f *fakeIssuer) defaultOpts() oidcOptions {
 		issuerURL:            f.server.URL,
 		clientID:             "test-client",
 		usernameClaim:        "sub",
-		caFile:               f.caFile,
+		caConfigMap:          "oidc-ca",
 		signingAlgs:          []string{oidc.RS256},
 		reservedNamePrefixes: []string{"system:"}, // the --oidc-reserved-name-prefixes flag default
 	}
@@ -290,7 +301,7 @@ func TestOIDCAuthenticator_ClaimMapping(t *testing.T) {
 			if tt.opts != nil {
 				tt.opts(&opts)
 			}
-			authn := newOIDCAuthenticator(t.Context(), opts)
+			authn := issuer.newAuthenticator(t, opts)
 
 			token := issuer.signToken(t, issuer.claims(tt.claims))
 			resp, ok, err := authenticateUntilSettled(t, authn, token, 5*time.Second)
@@ -380,7 +391,7 @@ func TestOIDCAuthenticator_HealthSnapshot(t *testing.T) {
 
 func TestOIDCAuthenticator_MalformedToken(t *testing.T) {
 	issuer := newFakeIssuer(t)
-	authn := newOIDCAuthenticator(t.Context(), issuer.defaultOpts())
+	authn := issuer.newAuthenticator(t, issuer.defaultOpts())
 
 	for _, token := range []string{"garbage", "a.b", "a.!!!.c", ""} {
 		resp, ok, err := authn.AuthenticateToken(context.Background(), token)
@@ -399,7 +410,7 @@ func TestOIDCAuthenticator_MalformedToken(t *testing.T) {
 func TestOIDCAuthenticator_ForeignIssuer(t *testing.T) {
 	issuer := newFakeIssuer(t)
 
-	authn := newOIDCAuthenticator(t.Context(), issuer.defaultOpts())
+	authn := issuer.newAuthenticator(t, issuer.defaultOpts())
 	token := issuer.signToken(t, issuer.claims(map[string]any{"iss": "https://foreign.example.com"}))
 
 	_, ok, err := authn.AuthenticateToken(context.Background(), token)
@@ -416,7 +427,7 @@ func TestOIDCAuthenticator_IssuerUnreachable(t *testing.T) {
 	token := issuer.signToken(t, issuer.claims(nil))
 	issuer.server.Close()
 
-	authn := newOIDCAuthenticator(t.Context(), issuer.defaultOpts())
+	authn := issuer.newAuthenticator(t, issuer.defaultOpts())
 	resp, ok, err := authn.AuthenticateToken(context.Background(), token)
 	if err == nil {
 		t.Fatal("expected error when issuer is unreachable")
@@ -432,13 +443,28 @@ func TestOIDCAuthenticator_IssuerUnreachable(t *testing.T) {
 	}
 }
 
+func TestOIDCAuthenticator_EagerSystemRootInitialization(t *testing.T) {
+	issuer := newFakeIssuer(t)
+	opts := issuer.defaultOpts()
+	opts.caConfigMap = ""
+	authn := mustNewOIDCAuthenticator(t, opts)
+
+	authn.mu.RLock()
+	defer authn.mu.RUnlock()
+	if authn.delegate == nil || authn.initializationError != nil {
+		t.Fatalf("expected system-root authenticator to initialize eagerly, got delegate=%v err=%v",
+			authn.delegate, authn.initializationError)
+	}
+}
+
 func TestOIDCAuthenticator_DiscoveryRetry(t *testing.T) {
 	issuer := newFakeIssuer(t)
-	authn := newOIDCAuthenticator(t.Context(), issuer.defaultOpts())
+	issuer.failDiscovery.Store(true)
+	authn := issuer.newAuthenticator(t, issuer.defaultOpts())
 	token := issuer.signToken(t, issuer.claims(nil))
 
-	// first request fails discovery -> infrastructure error, not cached
-	issuer.failDiscovery.Store(true)
+	// Discovery begins eagerly and an authentication request observes its
+	// infrastructure error while the issuer remains unavailable.
 	_, ok, err := authn.AuthenticateToken(context.Background(), token)
 	if err == nil || ok {
 		t.Fatalf("expected discovery failure, got ok=%v err=%v", ok, err)
@@ -474,38 +500,6 @@ func TestOIDCAuthenticator_DiscoveryRetry(t *testing.T) {
 	issuer.failDiscovery.Store(true)
 	if _, ok, err := authn.AuthenticateToken(context.Background(), token); err != nil || !ok {
 		t.Fatalf("expected cached verifier to keep working, got ok=%v err=%v", ok, err)
-	}
-}
-
-func TestOIDCAuthenticator_CAFileMissing(t *testing.T) {
-	issuer := newFakeIssuer(t)
-	token := issuer.signToken(t, issuer.claims(nil))
-
-	caFile := filepath.Join(t.TempDir(), "missing.crt")
-	opts := issuer.defaultOpts()
-	opts.caFile = caFile
-	authn := newOIDCAuthenticator(t.Context(), opts)
-
-	_, ok, err := authn.AuthenticateToken(context.Background(), token)
-	if err == nil || ok {
-		t.Fatalf("expected CA file error, got ok=%v err=%v", ok, err)
-	}
-	if errors.Is(err, ErrTokenNotAuthenticated) {
-		t.Fatal("missing CA file should NOT be wrapped with ErrTokenNotAuthenticated")
-	}
-	if !strings.Contains(err.Error(), "failed to read oidc CA file") {
-		t.Fatalf("expected CA file read error, got: %v", err)
-	}
-
-	if err := os.WriteFile(caFile, issuer.caPEM, 0600); err != nil {
-		t.Fatalf("failed to create late OIDC CA file: %v", err)
-	}
-	resp, ok, err := authenticateUntilSettled(t, authn, token, 5*time.Second)
-	if err != nil || !ok {
-		t.Fatalf("expected authentication to recover after CA creation, got ok=%v err=%v", ok, err)
-	}
-	if wantName := issuer.server.URL + "#test-user"; resp.User.GetName() != wantName {
-		t.Fatalf("expected username %q, got %q", wantName, resp.User.GetName())
 	}
 }
 
@@ -636,6 +630,7 @@ func TestOIDCFlagParsing(t *testing.T) {
 	}
 
 	err := cmd.ParseFlags([]string{
+		"--oidc-ca-configmap=oidc-ca",
 		"--oidc-signing-algs=RS256,ES256",
 		"--oidc-required-claim=hd=example.com",
 		"--oidc-required-claim=tenant=value=with=equals",
@@ -646,6 +641,9 @@ func TestOIDCFlagParsing(t *testing.T) {
 	}
 	if !slices.Equal(factory.options.signingAlgs, []string{"RS256", "ES256"}) {
 		t.Fatalf("unexpected signing algorithms: %v", factory.options.signingAlgs)
+	}
+	if factory.options.caConfigMap != "oidc-ca" {
+		t.Fatalf("unexpected OIDC CA ConfigMap: %q", factory.options.caConfigMap)
 	}
 	if !slices.Equal(factory.options.reservedNamePrefixes, []string{"system:", "dev:"}) {
 		t.Fatalf("unexpected reserved name prefixes: %v", factory.options.reservedNamePrefixes)

--- a/pkg/serviceproxy/oidc_configmap_controller.go
+++ b/pkg/serviceproxy/oidc_configmap_controller.go
@@ -1,0 +1,147 @@
+package serviceproxy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+)
+
+const (
+	oidcCAConfigMapKey         = "ca.crt"
+	oidcCAInformerResyncPeriod = 10 * time.Minute
+)
+
+type oidcCAConfigMapController struct {
+	namespace     string
+	name          string
+	lister        listerscorev1.ConfigMapLister
+	authenticator *oidcAuthenticator
+}
+
+// startOIDCCAConfigMapController starts a single-key controller for the OIDC
+// CA ConfigMap. The initial reconciliation runs after the informer cache has
+// synced, so discovery starts before the service proxy begins serving when the
+// ConfigMap already exists.
+func startOIDCCAConfigMapController(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	name string,
+	authenticator *oidcAuthenticator,
+) error {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		oidcCAInformerResyncPeriod,
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", name).String()
+		}),
+	)
+
+	configMapInformer := informerFactory.Core().V1().ConfigMaps()
+	reconciler := &oidcCAConfigMapController{
+		namespace:     namespace,
+		name:          name,
+		lister:        configMapInformer.Lister(),
+		authenticator: authenticator,
+	}
+	controller := factory.New().
+		WithInformersQueueKeysFunc(factory.DefaultQueueKeysFunc, configMapInformer.Informer()).
+		WithSync(reconciler.sync).
+		ToController("oidc-ca-configmap-controller")
+
+	informerFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), configMapInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to sync OIDC CA ConfigMap informer: %w", ctx.Err())
+	}
+	if err := reconciler.reconcile(ctx); err != nil {
+		return err
+	}
+
+	go controller.Run(ctx, 1)
+	return nil
+}
+
+func (c *oidcCAConfigMapController) sync(
+	ctx context.Context,
+	_ factory.SyncContext,
+	_ string,
+) error {
+	return c.reconcile(ctx)
+}
+
+func (c *oidcCAConfigMapController) reconcile(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	configMap, err := c.lister.ConfigMaps(c.namespace).Get(c.name)
+	if apierrors.IsNotFound(err) {
+		unavailableError := fmt.Errorf("OIDC CA ConfigMap %s/%s is not available", c.namespace, c.name)
+		if c.authenticator.markUnavailable("configmap-missing", unavailableError) {
+			logger.Info("OIDC authenticator is waiting for its CA ConfigMap",
+				"namespace", c.namespace,
+				"name", c.name,
+			)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get OIDC CA ConfigMap %s/%s from informer cache: %w", c.namespace, c.name, err)
+	}
+
+	caBundle, err := oidcCABundle(configMap)
+	if err != nil {
+		configurationKey := caConfigurationKey("configmap-invalid", []byte(err.Error()))
+		if c.authenticator.markUnavailable(configurationKey, err) {
+			logger.Error(err, "OIDC authenticator CA configuration is invalid",
+				"namespace", c.namespace,
+				"name", c.name,
+			)
+		}
+		return nil
+	}
+
+	configurationKey := caConfigurationKey("configmap", caBundle)
+	changed, err := c.authenticator.reconcileCABundle(configurationKey, caBundle)
+	if err != nil {
+		logger.Error(err, "failed to reconcile OIDC authenticator",
+			"namespace", c.namespace,
+			"name", c.name,
+		)
+		return nil
+	}
+
+	if changed {
+		logger.Info("OIDC CA configuration reconciled",
+			"namespace", c.namespace,
+			"name", c.name,
+		)
+	}
+	return nil
+}
+
+func oidcCABundle(configMap *corev1.ConfigMap) ([]byte, error) {
+	caBundle, ok := configMap.BinaryData[oidcCAConfigMapKey]
+	if data, dataOK := configMap.Data[oidcCAConfigMapKey]; dataOK {
+		caBundle, ok = []byte(data), true
+	}
+	if !ok {
+		return nil, fmt.Errorf("OIDC CA ConfigMap %s/%s does not contain %s",
+			configMap.Namespace, configMap.Name, oidcCAConfigMapKey)
+	}
+	if len(caBundle) == 0 {
+		return nil, fmt.Errorf("OIDC CA ConfigMap %s/%s has an empty %s entry",
+			configMap.Namespace, configMap.Name, oidcCAConfigMapKey)
+	}
+	return caBundle, nil
+}

--- a/pkg/serviceproxy/oidc_configmap_controller_test.go
+++ b/pkg/serviceproxy/oidc_configmap_controller_test.go
@@ -1,0 +1,349 @@
+package serviceproxy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	oidcauthenticator "k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
+	"k8s.io/client-go/kubernetes/fake"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type oidcDelegateBuild struct {
+	ctx      context.Context
+	caBundle string
+}
+
+func TestOIDCCAConfigMapControllerRespondsToEvents(t *testing.T) {
+	const (
+		namespace = "addon"
+		name      = "oidc-ca"
+	)
+
+	authn := mustNewOIDCAuthenticator(t, oidcOptions{caConfigMap: name})
+	builds := make(chan oidcDelegateBuild, 2)
+	authn.newDelegate = func(ctx context.Context, caBundle []byte) (oidcauthenticator.AuthenticatorTokenWithHealthCheck, func(), error) {
+		builds <- oidcDelegateBuild{ctx: ctx, caBundle: string(caBundle)}
+		return &fakeOIDCDelegate{authenticateToken: func(context.Context, string) (*authenticator.Response, bool, error) {
+			return nil, false, nil
+		}}, nil, nil
+	}
+
+	client := fake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if err := startOIDCCAConfigMapController(ctx, client, namespace, name, authn); err != nil {
+		t.Fatalf("start ConfigMap controller: %v", err)
+	}
+	assertOIDCUnavailable(t, authn, "is not available")
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data:       map[string]string{oidcCAConfigMapKey: "event-ca"},
+	}
+	if _, err := client.CoreV1().ConfigMaps(namespace).Create(t.Context(), configMap, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create ConfigMap: %v", err)
+	}
+	firstBuild := awaitDelegateBuild(t, builds)
+	if firstBuild.caBundle != "event-ca" {
+		t.Fatalf("expected event CA, got %q", firstBuild.caBundle)
+	}
+
+	if err := client.CoreV1().ConfigMaps(namespace).Delete(t.Context(), name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete ConfigMap: %v", err)
+	}
+	select {
+	case <-firstBuild.ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("ConfigMap deletion did not cancel the active delegate")
+	}
+	assertOIDCUnavailable(t, authn, "is not available")
+
+	if _, err := client.CoreV1().ConfigMaps(namespace).Create(t.Context(), configMap, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("recreate ConfigMap: %v", err)
+	}
+	secondBuild := awaitDelegateBuild(t, builds)
+	if secondBuild.caBundle != "event-ca" {
+		t.Fatalf("expected recreated event CA, got %q", secondBuild.caBundle)
+	}
+}
+
+func awaitDelegateBuild(t *testing.T, builds <-chan oidcDelegateBuild) oidcDelegateBuild {
+	t.Helper()
+	select {
+	case build := <-builds:
+		return build
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OIDC delegate reconciliation")
+		return oidcDelegateBuild{}
+	}
+}
+
+// newTestOIDCCAConfigMapController builds a controller that reads ConfigMaps
+// from a caller-populated indexer instead of a running informer.
+func newTestOIDCCAConfigMapController(
+	namespace, name string,
+	authn *oidcAuthenticator,
+) (*oidcCAConfigMapController, cache.Indexer) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	return &oidcCAConfigMapController{
+		namespace:     namespace,
+		name:          name,
+		lister:        listerscorev1.NewConfigMapLister(indexer),
+		authenticator: authn,
+	}, indexer
+}
+
+func TestOIDCCAConfigMapReconciliation(t *testing.T) {
+	const (
+		namespace = "addon"
+		name      = "oidc-ca"
+	)
+
+	authn := mustNewOIDCAuthenticator(t, oidcOptions{caConfigMap: name})
+
+	var (
+		observedBundles [][]byte
+		delegateCtxs    []context.Context
+	)
+	authn.newDelegate = func(ctx context.Context, caBundle []byte) (oidcauthenticator.AuthenticatorTokenWithHealthCheck, func(), error) {
+		observedBundles = append(observedBundles, caBundle)
+		delegateCtxs = append(delegateCtxs, ctx)
+		username := string(caBundle)
+		return &fakeOIDCDelegate{authenticateToken: func(context.Context, string) (*authenticator.Response, bool, error) {
+			return &authenticator.Response{User: &user.DefaultInfo{Name: username}}, true, nil
+		}}, nil, nil
+	}
+
+	controller, indexer := newTestOIDCCAConfigMapController(namespace, name, authn)
+
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile missing ConfigMap: %v", err)
+	}
+	assertOIDCUnavailable(t, authn, "is not available")
+	if len(observedBundles) != 0 {
+		t.Fatalf("request-independent initialization should wait for the ConfigMap, got %d builds", len(observedBundles))
+	}
+
+	first := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, ResourceVersion: "1"},
+		Data:       map[string]string{oidcCAConfigMapKey: "ca-one"},
+	}
+	if err := indexer.Add(first); err != nil {
+		t.Fatalf("add first ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile first ConfigMap: %v", err)
+	}
+	assertOIDCUsername(t, authn, "ca-one")
+	if len(observedBundles) != 1 || string(observedBundles[0]) != "ca-one" {
+		t.Fatalf("unexpected first reconciliation: %q", observedBundles)
+	}
+
+	metadataOnly := first.DeepCopy()
+	metadataOnly.ResourceVersion = "2"
+	metadataOnly.Labels = map[string]string{"changed": "true"}
+	if err := indexer.Update(metadataOnly); err != nil {
+		t.Fatalf("update ConfigMap metadata: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile metadata-only update: %v", err)
+	}
+	if len(observedBundles) != 1 {
+		t.Fatalf("metadata-only update rebuilt the delegate %d times", len(observedBundles))
+	}
+
+	rotated := metadataOnly.DeepCopy()
+	rotated.ResourceVersion = "3"
+	rotated.Data[oidcCAConfigMapKey] = "ca-two"
+	if err := indexer.Update(rotated); err != nil {
+		t.Fatalf("rotate ConfigMap CA: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile CA rotation: %v", err)
+	}
+	assertOIDCUsername(t, authn, "ca-two")
+	if len(observedBundles) != 2 || string(observedBundles[1]) != "ca-two" {
+		t.Fatalf("unexpected CA rotation: %q", observedBundles)
+	}
+	assertContextCanceled(t, delegateCtxs[0])
+
+	if err := indexer.Delete(rotated); err != nil {
+		t.Fatalf("delete ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile ConfigMap deletion: %v", err)
+	}
+	assertOIDCUnavailable(t, authn, "is not available")
+	assertContextCanceled(t, delegateCtxs[1])
+
+	invalid := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, ResourceVersion: "4"},
+	}
+	if err := indexer.Add(invalid); err != nil {
+		t.Fatalf("add invalid ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile invalid ConfigMap: %v", err)
+	}
+	assertOIDCUnavailable(t, authn, "does not contain ca.crt")
+	if len(observedBundles) != 2 {
+		t.Fatalf("invalid ConfigMap unexpectedly rebuilt the delegate %d times", len(observedBundles))
+	}
+
+	recovered := invalid.DeepCopy()
+	recovered.ResourceVersion = "5"
+	recovered.BinaryData = map[string][]byte{oidcCAConfigMapKey: []byte("ca-three")}
+	if err := indexer.Update(recovered); err != nil {
+		t.Fatalf("repair ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile repaired ConfigMap: %v", err)
+	}
+	assertOIDCUsername(t, authn, "ca-three")
+	if len(observedBundles) != 3 || string(observedBundles[2]) != "ca-three" {
+		t.Fatalf("unexpected recovery reconciliation: %q", observedBundles)
+	}
+}
+
+func TestOIDCCAConfigMapRejectsMalformedBundleAndRecovers(t *testing.T) {
+	const (
+		namespace = "addon"
+		name      = "oidc-ca"
+	)
+	issuer := newFakeIssuer(t)
+	opts := issuer.defaultOpts()
+	opts.caConfigMap = name
+	authn := mustNewOIDCAuthenticator(t, opts)
+
+	controller, indexer := newTestOIDCCAConfigMapController(namespace, name, authn)
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, ResourceVersion: "1"},
+		Data:       map[string]string{oidcCAConfigMapKey: "not-a-certificate"},
+	}
+	if err := indexer.Add(configMap); err != nil {
+		t.Fatalf("add malformed CA ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile malformed CA ConfigMap: %v", err)
+	}
+	assertOIDCUnavailable(t, authn, "failed to load oidc CA bundle")
+
+	repaired := configMap.DeepCopy()
+	repaired.ResourceVersion = "2"
+	repaired.Data[oidcCAConfigMapKey] = string(issuer.caPEM)
+	if err := indexer.Update(repaired); err != nil {
+		t.Fatalf("repair CA ConfigMap: %v", err)
+	}
+	if err := controller.reconcile(t.Context()); err != nil {
+		t.Fatalf("reconcile repaired CA ConfigMap: %v", err)
+	}
+
+	token := issuer.signToken(t, issuer.claims(nil))
+	response, ok, err := authenticateUntilSettled(t, authn, token, 5*time.Second)
+	if err != nil || !ok {
+		t.Fatalf("expected authentication recovery, got ok=%v err=%v", ok, err)
+	}
+	if want := issuer.server.URL + "#test-user"; response.User.GetName() != want {
+		t.Fatalf("expected username %q, got %q", want, response.User.GetName())
+	}
+}
+
+func assertOIDCUnavailable(t *testing.T, authn *oidcAuthenticator, errorSubstring string) {
+	t.Helper()
+	response, ok, err := authn.AuthenticateToken(t.Context(), "token")
+	if err == nil || !strings.Contains(err.Error(), errorSubstring) {
+		t.Fatalf("expected unavailable error containing %q, got %v", errorSubstring, err)
+	}
+	if errors.Is(err, ErrTokenNotAuthenticated) {
+		t.Fatalf("configuration error must not be a token rejection: %v", err)
+	}
+	if ok || response != nil {
+		t.Fatalf("expected nil unauthenticated response, got ok=%v response=%v", ok, response)
+	}
+}
+
+func assertOIDCUsername(t *testing.T, authn *oidcAuthenticator, expected string) {
+	t.Helper()
+	response, ok, err := authn.AuthenticateToken(t.Context(), "token")
+	if err != nil || !ok {
+		t.Fatalf("expected authentication success, got ok=%v err=%v", ok, err)
+	}
+	if response.User.GetName() != expected {
+		t.Fatalf("expected username %q, got %q", expected, response.User.GetName())
+	}
+}
+
+func assertContextCanceled(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected replaced delegate context to be canceled")
+	}
+}
+
+func TestOIDCCABundle(t *testing.T) {
+	tests := []struct {
+		name       string
+		configMap  *corev1.ConfigMap
+		wantBundle string
+		wantError  string
+	}{
+		{
+			name:       "data",
+			configMap:  &corev1.ConfigMap{Data: map[string]string{oidcCAConfigMapKey: "text-ca"}},
+			wantBundle: "text-ca",
+		},
+		{
+			name:       "binary data",
+			configMap:  &corev1.ConfigMap{BinaryData: map[string][]byte{oidcCAConfigMapKey: []byte("binary-ca")}},
+			wantBundle: "binary-ca",
+		},
+		{
+			name:      "missing key",
+			configMap: &corev1.ConfigMap{},
+			wantError: "does not contain ca.crt",
+		},
+		{
+			name:      "empty data",
+			configMap: &corev1.ConfigMap{Data: map[string]string{oidcCAConfigMapKey: ""}},
+			wantError: "empty ca.crt entry",
+		},
+		{
+			name:      "empty binary data",
+			configMap: &corev1.ConfigMap{BinaryData: map[string][]byte{oidcCAConfigMapKey: {}}},
+			wantError: "empty ca.crt entry",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.configMap.Namespace = "addon"
+			tt.configMap.Name = "oidc-ca"
+			bundle, err := oidcCABundle(tt.configMap)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(bundle) != tt.wantBundle {
+				t.Fatalf("expected bundle %q, got %q", tt.wantBundle, bundle)
+			}
+		})
+	}
+}

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -433,12 +433,14 @@ variables:
 | `oidcGroupsClaim` | `--oidc-groups-claim` | Empty; no IdP groups | Claim containing a string or array of group names. |
 | `oidcGroupsPrefix` | `--oidc-groups-prefix` | Empty | Prefix applied to every mapped group. |
 | `oidcReservedNamePrefixes` | `--oidc-reserved-name-prefixes` | `system:` | Comma-separated prefixes forbidden for mapped usernames and groups. |
-| `oidcCAConfigMap` | `--oidc-ca-file` | Empty; host root CAs | ConfigMap containing the private issuer CA under `ca.crt`. |
+| `oidcCAConfigMap` | `--oidc-ca-configmap` | Empty; host root CAs | Watched ConfigMap containing the private issuer CA under `ca.crt`. |
 | `oidcSigningAlgs` | `--oidc-signing-algs` | `RS256` | Comma-separated allowed JOSE asymmetric signing algorithms. |
 | `oidcRequiredClaimsJSON` | repeated `--oidc-required-claim` | Empty | JSON object whose string key/value pairs must appear in the token. |
 
-The standalone binary exposes the same behavior through its `--oidc-*` flags.
-Run `cluster-proxy service-proxy --help` to inspect the CLI defaults.
+The service-proxy command exposes the same behavior through its `--oidc-*`
+flags. Private issuer CAs are configured with `--oidc-ca-configmap`; omit it
+to use the host root CAs. Run `cluster-proxy service-proxy --help` to inspect
+the CLI defaults.
 
 Important security behavior:
 
@@ -453,9 +455,6 @@ Important security behavior:
   `true`.
 - Configure `oidcGroupsPrefix` when external group names could collide with
   existing managed cluster RBAC subjects.
-- Issuer discovery and JWKS initialization are lazy. An unavailable issuer
-  does not crash-loop service-proxy or affect TokenReview authentication; OIDC
-  requests fail until the issuer is available.
 
 ### Configure OIDC for one managed cluster
 
@@ -609,12 +608,11 @@ publicly trusted certificate, or replace it with
 
 ### OIDC CA lifecycle
 
-The `oidcCAConfigMap` volume is optional so the Pod can start before the
-ConfigMap exists. When the value is configured, a valid `ca.crt` must be
-available before an OIDC request can initialize the authenticator. If the
-first request arrives too early, it fails without affecting the TokenReview
-paths; a later request can initialize successfully after the ConfigMap is
-created. No Pod restart is required.
+When `oidcCAConfigMap` is set, service-proxy watches that ConfigMap in its
+namespace and applies changes without a Pod restart. A missing or invalid
+`ca.crt` disables OIDC authentication until corrected. If the issuer is
+unavailable, discovery retries in the background without affecting
+service-proxy or TokenReview authentication.
 
 ### Automated coverage
 

--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -198,13 +198,13 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.initializeAuthProviders(ctx); err != nil {
-		return err
-	}
-
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
 		return errors.New("pod namespace is empty, please set the POD_NAMESPACE environment variable")
+	}
+
+	if err := s.initializeAuthProviders(runCtx, podNamespace); err != nil {
+		return err
 	}
 
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, s.managedClusterKubeClient, podNamespace, func() {

--- a/test/e2e/oidc_test.go
+++ b/test/e2e/oidc_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	"open-cluster-management.io/cluster-proxy/pkg/common"
 	"open-cluster-management.io/cluster-proxy/pkg/config"
 )
 
@@ -57,8 +58,8 @@ var _ = Describe("OIDC Authentication Test", Label("serviceproxy", "oidc"), Orde
 		dexCA := dexTLSSecret.Data["ca.crt"]
 		Expect(dexCA).ToNot(BeEmpty())
 
-		By("Create or refresh the OIDC CA ConfigMap in the spoke addon namespace")
-		applyConfigMap(managedClusterInstallNamespace, oidcCAConfigMapName, map[string]string{"ca.crt": string(dexCA)})
+		By("Ensure the OIDC CA ConfigMap is initially absent")
+		deleteConfigMap(managedClusterInstallNamespace, oidcCAConfigMapName)
 
 		By("Cleanup existing AddOnDeploymentConfig if any")
 		Expect(deleteAddOnDeploymentConfig(oidcDeployConfigName)).To(Succeed())
@@ -114,6 +115,13 @@ var _ = Describe("OIDC Authentication Test", Label("serviceproxy", "oidc"), Orde
 		By("Wait for the oidc flags to appear in the service-proxy container")
 		waitServiceProxyOIDCArgs(true)
 		waitManagedClusterAddonAvailable()
+		podsBeforeCA := proxyAgentPodRestartCounts()
+
+		By("Create the OIDC CA ConfigMap after service-proxy is running")
+		applyConfigMap(managedClusterInstallNamespace, oidcCAConfigMapName, map[string]string{"ca.crt": string(dexCA)})
+
+		By("Ensure CA reconciliation does not restart the proxy agent")
+		Consistently(proxyAgentPodRestartCounts).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(Equal(podsBeforeCA))
 
 		By("Obtain a real ID token from Dex via the password grant")
 		dexPool, err := certutil.NewPoolFromBytes(dexCA)
@@ -136,8 +144,8 @@ var _ = Describe("OIDC Authentication Test", Label("serviceproxy", "oidc"), Orde
 	})
 
 	It("should report the impersonated OIDC identity", func() {
-		// the first request also triggers the service-proxy's lazy OIDC
-		// provider discovery, hence the Eventually
+		// ConfigMap reconciliation starts provider discovery asynchronously, so
+		// allow the Kubernetes OIDC authenticator to finish its initial attempt.
 		Eventually(func() error {
 			review, err := oidcProxyClient.AuthenticationV1().SelfSubjectReviews().Create(
 				context.Background(), &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
@@ -237,6 +245,30 @@ func waitServiceProxyOIDCArgs(expectPresent bool) {
 		}
 		return proxyAgentRolledOut(deploy, ptr.Deref(deploy.Spec.Replicas, 1))
 	}).WithTimeout(7 * time.Minute).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+}
+
+// proxyAgentPodRestartCounts snapshots the proxy agent pods as UID to summed
+// container restart count, so both a Deployment rollout (new pods) and an
+// in-place container restart are visible as a change.
+func proxyAgentPodRestartCounts() map[string]int32 {
+	podList, err := hubKubeClient.CoreV1().
+		Pods(config.DefaultAddonInstallNamespace).
+		List(context.TODO(), metav1.ListOptions{
+			LabelSelector: common.LabelKeyComponentName + "=" + common.ComponentNameProxyAgent,
+		})
+	Expect(err).ToNot(HaveOccurred())
+	counts := map[string]int32{}
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		var restarts int32
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			restarts += containerStatus.RestartCount
+		}
+		counts[string(pod.UID)] = restarts
+	}
+	return counts
 }
 
 // requestDexIDToken performs a resource owner password grant against Dex and


### PR DESCRIPTION
## Why

OIDC settings are delivered before user traffic, but the verifier was initialized lazily by the first bearer-token request. That request therefore had two jobs: start issuer discovery/JWKS loading and authenticate the user. Because discovery is asynchronous, a valid first request could observe the verifier before it was ready and receive a 401; retrying later would then succeed.

A user request should not be the readiness trigger for authentication infrastructure. The goal here is that, once the configured state has converged, the first valid OIDC request only performs authentication. This removes lazy initialization as a cause of first-request 401s without hiding genuine issuer or CA failures.

## Approach

Treat OIDC configuration as desired state and reconcile it independently from request traffic.

```mermaid
sequenceDiagram
    participant A as Add-on configuration
    participant S as service-proxy
    participant I as OIDC issuer
    participant C as Client

    Note over S,C: Before: request-driven initialization
    C->>S: First valid OIDC token
    S->>I: Start discovery and JWKS loading
    S-->>C: 401 while verifier is not ready
    I-->>S: Verifier becomes ready

    Note over A,C: After: configuration-driven initialization
    A->>S: OIDC settings or CA ConfigMap event
    S->>I: Start discovery and JWKS loading
    I-->>S: Verifier becomes ready
    C->>S: First valid OIDC token
    S-->>C: Authenticated request
```

Static settings are reconciled during startup. For ConfigMap-backed CAs, the initial informer state and create, update, and delete events all invoke the same idempotent reconciliation path. This also gives CA correction and rotation a lifecycle that does not require a Pod rollout.

This is intentionally not a request-side retry or a ConfigMap polling loop. Kubernetes already gives us events for desired-state changes, while its OIDC authenticator owns asynchronous retries for issuer discovery. Missing, deleted, or invalid CA data fails OIDC closed and cancels the previous verifier; managed-cluster and hub TokenReview authentication remain available.

## Validation

Verified manually on a kind hub with two managed clusters, using Dex
as the OIDC issuer and real tokens:

- Creating the CA ConfigMap after startup enables OIDC without a pod
  restart or rollout.
- Deleting the ConfigMap, or replacing its data with malformed PEM,
  makes OIDC requests fail with 401 while managed-cluster and hub
  TokenReview authentication keep working.
- Restoring valid CA data recovers OIDC in place.
- Metadata-only ConfigMap updates do not re-trigger initialization.

