### PR TITLE
:seedling: chore: prepare for v0.11.0 release

### DIFF
--- a/charts/cluster-proxy/Chart.yaml
+++ b/charts/cluster-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-proxy
 description: A Helm chart for Cluster-Proxy OCM Addon
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.1.0
 dependencies:
   - name: cluster-proxy-common


### PR DESCRIPTION
The old v0.10.0 release is too old. Let's just get an emergency v0.11.0 release out. We can do another release when we feel needed.