### PR TITLE
:sparkles: fix(user-server): add liveness probe

### DIFF
--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -76,6 +76,12 @@ spec:
             privileged: false
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
The user-server already exposes an HTTP health endpoint on port 8000, but its Deployment does not configure Kubernetes to use it for liveness checks.
