### PR TITLE
📖 docs(serviceproxy): clarify enableImpersonation behavior

### DIFF
--- a/charts/cluster-proxy/README.md
+++ b/charts/cluster-proxy/README.md
@@ -37,7 +37,7 @@ helm install cluster-proxy ./charts/cluster-proxy \
 | `installByPlacement.placementNamespace` | Namespace containing the Placement                               | Release namespace when empty                    |
 | `enableKubeApiProxy`                    | Enable Kubernetes API proxy support                               | `true`                                          |
 | `enableServiceProxy`                    | Deploy the hub user-server and managed cluster service-proxy      | `false`                                         |
-| `enableImpersonation`                   | Grant hub permissions required for service-proxy impersonation    | `true`                                          |
+| `enableImpersonation`                   | Grant permissions for hub token authentication                    | `true`                                          |
 | `featureGates.clusterProfile`           | Enable ClusterProfile integration                                | `false`                                         |
 | `userServer.enabled`                    | Generate and rotate the user-server serving certificate          | `false`                                         |
 | `userServer.additionalSANs`             | Extra SANs for the generated user-server certificate             | `[]`                                            |
@@ -59,8 +59,7 @@ helm install cluster-proxy ./charts/cluster-proxy \
   --set userServer.enabled=true
 ```
 
-`enableImpersonation` defaults to true and enables hub token authentication.
-OIDC authentication is configured independently per managed cluster.
+`enableImpersonation` defaults to true and grants the required hub permissions.
 
 #### User Server Serving Certificate
 

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -31,6 +31,7 @@ enableKubeApiProxy: true
 # Note: When userServer.enabled is true, the user server certificate will be automatically
 # generated and rotated by the controller. No manual secret creation is required.
 enableServiceProxy: false
+# Grant permissions for hub token authentication.
 enableImpersonation: true
 
 # Feature gates for alpha/experimental features

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.schema.json
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.schema.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "enableImpersonation": {
-      "description": "Enable service-proxy impersonation for hub identities.",
+      "description": "Enable hub token authentication.",
       "type": "string"
     },
     "global": {

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/values.yaml
@@ -55,7 +55,7 @@ proxyConfig:
   # @schema type:[string, null]
   NO_PROXY: null
 
-# -- Enable service-proxy impersonation for hub identities.
+# -- Enable hub token authentication.
 enableImpersonation: "true"
 
 # Opt-in NetworkPolicy for the spoke proxy-agent Deployment.

--- a/pkg/serviceproxy/hub_auth_provider.go
+++ b/pkg/serviceproxy/hub_auth_provider.go
@@ -49,7 +49,7 @@ func newHubAuthProviderFactory() *hubAuthProviderFactory {
 
 func (f *hubAuthProviderFactory) addFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.kubeConfig, "hub-kubeconfig", f.kubeConfig, "The kubeconfig file for connecting to the hub cluster")
-	flags.BoolVar(&f.enableImpersonation, "enable-impersonation", f.enableImpersonation, "Whether to enable impersonation")
+	flags.BoolVar(&f.enableImpersonation, "enable-impersonation", f.enableImpersonation, "Enable hub token authentication")
 }
 
 func (*hubAuthProviderFactory) validate() error {

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -90,11 +90,9 @@ user-server serving certificate. If you provide that certificate yourself,
 leave this value false and follow the
 [user-server certificate instructions](../../charts/cluster-proxy/README.md#user-server-serving-certificate).
 
-The top-level `enableImpersonation` Helm value grants the required
-hub permissions. To control hub TokenReview authentication per managed cluster,
-set the `enableImpersonation` AddOnDeploymentConfig variable, which
-maps to `--enable-impersonation` and defaults to true. OIDC authentication is
-configured independently and does not require this value to be enabled.
+The top-level `enableImpersonation` Helm value grants the required hub
+permissions. The per-cluster `enableImpersonation` variable enables hub token
+authentication in service-proxy and defaults to true.
 
 ## OpenShift LDAP hub-token verification
 


### PR DESCRIPTION
## Summary

`enableImpersonation` is really about hub token authentication. This tightens up the CLI help and related Helm/docs wording. No behavior changes.
