### PR TITLE
🐛 fix(proxyagent): render RBAC for additional authentication args

### DIFF
--- a/pkg/proxyagent/agent/agent_test.go
+++ b/pkg/proxyagent/agent/agent_test.go
@@ -1028,6 +1028,153 @@ func TestNewAgentAddon(t *testing.T) {
 	}
 }
 
+func TestImpersonationRBACConfiguration(t *testing.T) {
+	const (
+		addonName        = "open-cluster-management-cluster-proxy"
+		clusterName      = "cluster"
+		deployConfigName = "deploy-config"
+	)
+
+	tests := []struct {
+		name                string
+		enableServiceProxy  bool
+		enableImpersonation string
+		oidcIssuerURL       string
+		additionalArgs      []string
+		wantImpersonation   bool
+		wantError           string
+	}{
+		{
+			name:                "alternate typed true value",
+			enableServiceProxy:  true,
+			enableImpersonation: "T",
+			wantImpersonation:   true,
+		},
+		{
+			name:                "additional hub authentication equals form is rejected",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs:      []string{"--enable-impersonation=true"},
+			wantError:           "additionalServiceProxyArgs must not set --enable-impersonation",
+		},
+		{
+			name:                "additional hub authentication bare form is rejected",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs:      []string{"--enable-impersonation"},
+			wantError:           "additionalServiceProxyArgs must not set --enable-impersonation",
+		},
+		{
+			name:                "additional oidc equals form",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs: []string{
+				"--oidc-issuer-url=https://dex.example.com/dex",
+				"--oidc-client-id=cluster-proxy",
+			},
+			wantImpersonation: true,
+		},
+		{
+			name:                "additional oidc split form",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs: []string{
+				"--oidc-issuer-url", "https://dex.example.com/dex",
+				"--oidc-client-id", "cluster-proxy",
+			},
+			wantImpersonation: true,
+		},
+		{
+			name:                "disabled authentication arguments",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs: []string{
+				"--oidc-issuer-url=",
+			},
+		},
+		{
+			name:                "typed and additional oidc issuer are rejected",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			oidcIssuerURL:       "https://typed.example.com/dex",
+			additionalArgs: []string{
+				"--oidc-issuer-url=https://additional.example.com/dex",
+			},
+			wantError: "configure the OIDC issuer with either oidcIssuerURL or --oidc-issuer-url",
+		},
+		{
+			name:                "duplicate additional oidc issuer is rejected",
+			enableServiceProxy:  true,
+			enableImpersonation: "false",
+			additionalArgs: []string{
+				"--oidc-issuer-url=https://dex.example.com/dex",
+				"--oidc-issuer-url=",
+			},
+			wantError: "additionalServiceProxyArgs must set --oidc-issuer-url at most once",
+		},
+		{
+			name:                "disabled service proxy never grants impersonation",
+			enableImpersonation: "false",
+			additionalArgs: []string{
+				"--enable-impersonation=true",
+				"--oidc-issuer-url=https://dex.example.com/dex",
+				"--oidc-client-id=cluster-proxy",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proxyConfig := newManagedProxyConfig(ManagedClusterConfigurationName, proxyv1alpha1.EntryPointTypePortForward)
+			proxyConfig.Spec.ProxyAgent.AdditionalServiceProxyArgs = test.additionalArgs
+
+			addon := newAddOn(addonName, clusterName)
+			addon.Status.ConfigReferences = []addonv1beta1.ConfigReference{
+				newManagedProxyConfigReference(ManagedClusterConfigurationName),
+				newAddOndDeploymentConfigReference(deployConfigName, clusterName),
+			}
+			variables := []addonv1beta1.CustomizedVariable{
+				{Name: "enableImpersonation", Value: test.enableImpersonation},
+			}
+			if test.oidcIssuerURL != "" {
+				variables = append(variables,
+					addonv1beta1.CustomizedVariable{Name: "oidcIssuerURL", Value: test.oidcIssuerURL},
+					addonv1beta1.CustomizedVariable{Name: "oidcClientID", Value: "cluster-proxy"},
+				)
+			}
+			deploymentConfig := newAddOnDeploymentConfigWithVariables(deployConfigName, clusterName, variables...)
+
+			agentAddon, err := NewAgentAddon(
+				&fakeSelfSigner{t: t},
+				"test",
+				fakeruntime.NewClientBuilder().WithObjects(proxyConfig).Build(),
+				fakekube.NewSimpleClientset(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-proxy-service-proxy-server-cert", Namespace: "test"},
+					Data:       map[string][]byte{"tls.crt": []byte("testcrt"), "tls.key": []byte("testkey")},
+				}),
+				true,
+				test.enableServiceProxy,
+				false,
+				fakeaddon.NewSimpleClientset(deploymentConfig),
+			)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			manifests, err := agentAddon.Manifests(context.Background(), newCluster(clusterName, true), addon)
+			if test.wantError != "" {
+				assert.ErrorContains(t, err, test.wantError)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.wantImpersonation,
+				clusterRoleAllowsImpersonation(getClusterRole(manifests, "cluster-proxy-addon-agent-impersonator")))
+		})
+	}
+}
+
 func assertPodSecurityContext(t *testing.T, deploy *appsv1.Deployment) {
 	t.Helper()
 

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/_helpers.tpl
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/*
+Return true when the rendered service-proxy configuration may authenticate an
+identity that must be forwarded with Kubernetes impersonation.
+*/}}
+{{- define "cluster-proxy-agent.requiresImpersonation" -}}
+{{- $requiresImpersonation := or (has .Values.enableImpersonation (list "1" "t" "T" "TRUE" "true" "True")) (not (empty .Values.oidcIssuerURL)) -}}
+{{- $additionalHubAuthConfigured := false -}}
+{{- $additionalOIDCIssuerConfigured := false -}}
+{{- $duplicateAdditionalOIDCIssuer := false -}}
+{{- range $arg := .Values.additionalServiceProxyArgs -}}
+  {{- if or (eq $arg "--enable-impersonation") (hasPrefix "--enable-impersonation=" $arg) -}}
+    {{- $additionalHubAuthConfigured = true -}}
+  {{- end -}}
+  {{- if or (eq $arg "--oidc-issuer-url") (hasPrefix "--oidc-issuer-url=" $arg) -}}
+    {{- if $additionalOIDCIssuerConfigured -}}
+      {{- $duplicateAdditionalOIDCIssuer = true -}}
+    {{- else -}}
+      {{- $additionalOIDCIssuerConfigured = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $enablesOIDCAuth := or (eq $arg "--oidc-issuer-url") (and (hasPrefix "--oidc-issuer-url=" $arg) (ne $arg "--oidc-issuer-url=")) -}}
+  {{- if $enablesOIDCAuth -}}
+    {{- $requiresImpersonation = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.enableServiceProxy $additionalHubAuthConfigured -}}
+  {{- fail "additionalServiceProxyArgs must not set --enable-impersonation; use enableImpersonation instead" -}}
+{{- end -}}
+{{- if and .Values.enableServiceProxy $duplicateAdditionalOIDCIssuer -}}
+  {{- fail "additionalServiceProxyArgs must set --oidc-issuer-url at most once" -}}
+{{- end -}}
+{{- if and .Values.enableServiceProxy (not (empty .Values.oidcIssuerURL)) $additionalOIDCIssuerConfigured -}}
+  {{- fail "configure the OIDC issuer with either oidcIssuerURL or --oidc-issuer-url in additionalServiceProxyArgs, not both" -}}
+{{- end -}}
+{{- $requiresImpersonation -}}
+{{- end -}}

--- a/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-clusterrole.yaml
+++ b/pkg/proxyagent/agent/manifests/charts/addon-agent/templates/addon-agent-clusterrole.yaml
@@ -3,7 +3,8 @@ kind: ClusterRole
 metadata:
   name: cluster-proxy-addon-agent-impersonator
 rules:
-{{- if or (eq .Values.enableImpersonation "true") .Values.oidcIssuerURL }}
+{{- $requiresImpersonation := eq (include "cluster-proxy-agent.requiresImpersonation" .) "true" }}
+{{- if and .Values.enableServiceProxy $requiresImpersonation }}
 - apiGroups: [""]
   resources: ["users", "groups"]
   verbs: ["impersonate"]


### PR DESCRIPTION
`additionalServiceProxyArgs` can enable OIDC without setting `oidcIssuerURL`. The proxy then accepted credentials, but the chart omitted users/groups impersonation RBAC, causing managed-cluster requests to fail with 403.

This renders the rule for either configuration path. Configuring the same authentication option twice now fails during rendering instead of relying on argument order.
