### PR TITLE
:bug: reject malformed certificate blocks in CA bundles

### DIFF
--- a/pkg/serviceproxy/service_proxy.go
+++ b/pkg/serviceproxy/service_proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -150,35 +151,18 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		return err
 	}
 
-	// get root CAs
-	s.rootCAs = x509.NewCertPool()
-	// ca for accessing apiserver
-
-	apiserverPem, err := os.ReadFile(rootCAFile)
+	rootCAs, additionalCALoaded, err := loadRootCAs(rootCAFile, s.additionalServiceCA)
 	if err != nil {
 		return err
 	}
-	s.rootCAs.AppendCertsFromPEM(apiserverPem)
-
-	// ca for accessing additional services
-	if s.additionalServiceCA != "" {
-		additionalCAPem, err := os.ReadFile(s.additionalServiceCA)
+	s.rootCAs = rootCAs
+	if additionalCALoaded {
+		// add configchecker into http probes when additional-service-ca is provided
+		cc, err := addonutils.NewConfigChecker("additional-service-ca", s.additionalServiceCA)
 		if err != nil {
-			if os.IsNotExist(err) {
-				klog.Infof("additional-service-ca file not found: %s", s.additionalServiceCA)
-			} else {
-				return err
-			}
-		} else {
-			s.rootCAs.AppendCertsFromPEM(additionalCAPem)
-
-			// add configchecker into http probes when additional-service-ca is provided
-			cc, err := addonutils.NewConfigChecker("additional-service-ca", s.additionalServiceCA)
-			if err != nil {
-				return err
-			}
-			customChecks = append(customChecks, cc.Check)
+			return err
 		}
+		customChecks = append(customChecks, cc.Check)
 	}
 
 	s.proxyTransport = s.newProxyTransport()
@@ -234,6 +218,38 @@ func (s *serviceProxy) Run(ctx context.Context) error {
 		s.key,
 		healthServer,
 	)
+}
+
+// loadRootCAs builds the root CA pool from the apiserver CA and, when
+// configured and present, the additional service CA. The returned bool
+// reports whether the additional service CA was loaded.
+func loadRootCAs(rootCAFile, additionalServiceCA string) (*x509.CertPool, bool, error) {
+	// ca for accessing apiserver
+	rootCAs, err := certutil.NewPool(rootCAFile)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// ca for accessing additional services
+	if additionalServiceCA == "" {
+		return rootCAs, false, nil
+	}
+	additionalCAPem, err := os.ReadFile(additionalServiceCA)
+	if os.IsNotExist(err) {
+		klog.Infof("additional-service-ca file not found: %s", additionalServiceCA)
+		return rootCAs, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	additionalCerts, err := certutil.ParseCertsPEM(additionalCAPem)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse additional service CA %s: %w", additionalServiceCA, err)
+	}
+	for _, cert := range additionalCerts {
+		rootCAs.AddCert(cert)
+	}
+	return rootCAs, true, nil
 }
 
 func (s *serviceProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {

--- a/pkg/serviceproxy/service_proxy_test.go
+++ b/pkg/serviceproxy/service_proxy_test.go
@@ -1,6 +1,17 @@
 package serviceproxy
 
-import "testing"
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+)
 
 func TestNewServiceProxy_DefaultValues(t *testing.T) {
 	s := newServiceProxy()
@@ -14,4 +25,111 @@ func TestNewServiceProxy_DefaultValues(t *testing.T) {
 	if s.kubeClientBurst != defaultKubeClientBurst {
 		t.Fatalf("expected default burst %v, got %v", defaultKubeClientBurst, s.kubeClientBurst)
 	}
+}
+
+func TestLoadRootCAs(t *testing.T) {
+	caPEM := newTestCAPEM(t)
+	additionalCAPEM := newTestCAPEM(t)
+	malformedBundle := slices.Concat(caPEM, pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: []byte("not a DER-encoded certificate"),
+	}))
+
+	tests := []struct {
+		name                 string
+		rootCA               []byte
+		additionalCA         []byte
+		additionalCAMissing  bool
+		additionalCAIsDir    bool
+		wantErr              bool
+		wantAdditionalLoaded bool
+	}{
+		{
+			name:   "root CA only",
+			rootCA: caPEM,
+		},
+		{
+			name:                "missing additional CA file is tolerated",
+			rootCA:              caPEM,
+			additionalCAMissing: true,
+		},
+		{
+			name:                 "additional CA is loaded",
+			rootCA:               caPEM,
+			additionalCA:         additionalCAPEM,
+			wantAdditionalLoaded: true,
+		},
+		{
+			name:              "unreadable additional CA file is rejected",
+			rootCA:            caPEM,
+			additionalCAIsDir: true,
+			wantErr:           true,
+		},
+		{
+			name:    "malformed root CA is rejected",
+			rootCA:  malformedBundle,
+			wantErr: true,
+		},
+		{
+			name:         "malformed additional CA is rejected",
+			rootCA:       caPEM,
+			additionalCA: malformedBundle,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			rootCAFile := filepath.Join(dir, "ca.crt")
+			if err := os.WriteFile(rootCAFile, tt.rootCA, 0600); err != nil {
+				t.Fatal(err)
+			}
+			additionalCAFile := ""
+			switch {
+			case tt.additionalCAMissing:
+				additionalCAFile = filepath.Join(dir, "missing.crt")
+			case tt.additionalCAIsDir:
+				additionalCAFile = dir
+			case tt.additionalCA != nil:
+				additionalCAFile = filepath.Join(dir, "additional.crt")
+				if err := os.WriteFile(additionalCAFile, tt.additionalCA, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			rootCAs, additionalCALoaded, err := loadRootCAs(rootCAFile, additionalCAFile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantPool, err := certutil.NewPoolFromBytes(slices.Concat(tt.rootCA, tt.additionalCA))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !rootCAs.Equal(wantPool) {
+				t.Fatal("root CA pool does not contain the expected certificates")
+			}
+			if additionalCALoaded != tt.wantAdditionalLoaded {
+				t.Fatalf("expected additionalCALoaded=%v, got %v", tt.wantAdditionalLoaded, additionalCALoaded)
+			}
+		})
+	}
+}
+
+func newTestCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "test-ca"}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
 }

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -18,6 +18,7 @@ import (
 	grpccredentials "google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"k8s.io/client-go/kubernetes"
+	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
@@ -128,13 +129,9 @@ func (k *userServer) init(ctx context.Context) error {
 	}
 
 	// prepare ca for service proxy server
-	serviceProxyCaCert, err := os.ReadFile(k.serviceProxyCACertPath)
+	serviceProxyRootCA, err = certutil.NewPool(k.serviceProxyCACertPath)
 	if err != nil {
-		return err
-	}
-	serviceProxyRootCA = x509.NewCertPool()
-	if ok := serviceProxyRootCA.AppendCertsFromPEM(serviceProxyCaCert); !ok {
-		return fmt.Errorf("failed to parse service proxy ca cert")
+		return fmt.Errorf("failed to load service proxy ca cert: %w", err)
 	}
 
 	k.getTunnel = func(tunnelCtx context.Context) (konnectivity.Tunnel, error) {

--- a/pkg/util/secrets.go
+++ b/pkg/util/secrets.go
@@ -3,12 +3,12 @@ package util
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
 
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 )
@@ -53,8 +53,10 @@ func GetKonnectivityTLSConfig(restConfig *rest.Config, proxyConfig *proxyv1alpha
 }
 
 func buildTLSConfig(caData, certData, keyData []byte, serverName string, protos []string) (*tls.Config, error) {
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caData)
+	certPool, err := certutil.NewPoolFromBytes(caData)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed parsing CA data")
+	}
 	clientCert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
 		return nil, err

--- a/pkg/util/secrets_test.go
+++ b/pkg/util/secrets_test.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"slices"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestBuildTLSConfigCABundleValidation(t *testing.T) {
+	certPEM, keyPEM := newTestCertPEM(t)
+	nonCertificateBlock := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not a private key")})
+	malformedCertificateBlock := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a DER-encoded certificate")})
+
+	testcases := []struct {
+		name    string
+		caData  []byte
+		wantErr bool
+	}{
+		{
+			name:   "valid bundle",
+			caData: certPEM,
+		},
+		{
+			name:   "non-certificate block is ignored",
+			caData: slices.Concat(certPEM, nonCertificateBlock),
+		},
+		{
+			name:    "malformed certificate block is rejected",
+			caData:  slices.Concat(certPEM, malformedCertificateBlock),
+			wantErr: true,
+		},
+		{
+			name:   "truncated PEM block is skipped",
+			caData: slices.Concat(certPEM, []byte("-----BEGIN CERTIFICATE-----\nMIIBkTCCATeg\n")),
+		},
+		{
+			name:    "bundle without certificates is rejected",
+			caData:  []byte("no certificates here"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tlsCfg, err := buildTLSConfig(tc.caData, certPEM, keyPEM, "proxy.test", nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tlsCfg.RootCAs == nil {
+				t.Fatal("expected RootCAs to be set")
+			}
+		})
+	}
+}
+
+func newTestCertPEM(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "test-ca"}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}


### PR DESCRIPTION
Loading a CA bundle goes through `x509.CertPool.AppendCertsFromPEM`, which silently skips anything it cannot parse. A corrupted bundle is accepted as long as one certificate in it still parses (or, where the return value is ignored, even when nothing parses at all), and the process then quietly runs with partial trust, rejecting peers it should have accepted.

This switches the parsing to client-go's certutil, [the same code kube-apiserver uses when it reloads its client CA](https://github.com/kubernetes/kubernetes/blob/0f29094e5b73085e3802ecc1298ecae13866bfe6/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go#L269-L280). A CERTIFICATE block that does not parse now fails startup.

- service-proxy: the root CA assembly moves into `loadRootCAs` so the boundary is unit-testable. The `--additional-service-ca` file is still optional: a missing file is only logged, and the config checker is still registered only when the file was read. A file that exists but contains no valid certificate now fails startup instead of being silently ignored.
- user-server: the service proxy CA is loaded with `certutil.NewPool`, which also rejects bundles where only some blocks parse.
- `pkg/util` (e2e helper): `buildTLSConfig` now rejects CA data without any valid certificate; previously an unparseable bundle produced an empty pool and a confusing handshake failure later.

Non-certificate PEM blocks are still ignored, and bytes that never form a PEM block (a truncated block, for example) are still skipped, same as kube-apiserver.