### PR TITLE
🐛 fix(proxyserver): reconcile rendered resource changes after upgrades

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -32,6 +32,7 @@ const (
 	LabelKeyComponentName                = "proxy.open-cluster-management.io/component-name"
 	AnnotationKeyConfigurationGeneration = "proxy.open-cluster-management.io/configuration-generation"
 	AnnotationKeyTLSConfigHash           = "proxy.open-cluster-management.io/tls-config-hash"
+	AnnotationKeyRenderedHash            = "proxy.open-cluster-management.io/rendered-hash"
 )
 
 const (

--- a/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 	"open-cluster-management.io/cluster-proxy/pkg/common"
 	"open-cluster-management.io/cluster-proxy/pkg/constant"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -217,6 +219,13 @@ func (c *ManagedProxyConfigurationReconciler) deployProxyServer(config *proxyv1a
 }
 
 func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, gvk schema.GroupVersionKind, resource client.Object) (bool, bool, error) {
+	// hashing the rendered resource so that operator-side changes are applied even when the
+	// generation is unchanged. metadata is excluded to keep the hash stable on the retry below.
+	renderedHash, err := renderedResourceHash(resource)
+	if err != nil {
+		return false, false, errors.Wrapf(err, "failed hashing rendered resource kind: %s", gvk.Kind)
+	}
+
 	// appending a label to all the applied resources so that they can always be
 	// updated upon the configuration changes.
 	annotations := resource.GetAnnotations()
@@ -224,6 +233,7 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 		annotations = make(map[string]string)
 	}
 	annotations[common.AnnotationKeyConfigurationGeneration] = strconv.Itoa(int(incomingGeneration))
+	annotations[common.AnnotationKeyRenderedHash] = renderedHash
 	resource.SetAnnotations(annotations)
 
 	created := false
@@ -260,10 +270,10 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 		}
 	}
 
+	currentAnnotations := current.GetAnnotations()
 	var currentGeneration = 0
-	if current.GetAnnotations() != nil && len(current.GetAnnotations()[common.AnnotationKeyConfigurationGeneration]) > 0 {
-		var err error
-		currentGeneration, err = strconv.Atoi(current.GetAnnotations()[common.AnnotationKeyConfigurationGeneration])
+	if len(currentAnnotations[common.AnnotationKeyConfigurationGeneration]) > 0 {
+		currentGeneration, err = strconv.Atoi(currentAnnotations[common.AnnotationKeyConfigurationGeneration])
 		if err != nil {
 			return false, false, errors.Wrapf(err, "failed reading current generation for %v", gvk.Kind)
 		}
@@ -274,10 +284,11 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 		return created, false, nil
 	}
 
-	// update if generation bumped or TLS config changed
-	tlsHashChanged := resource.GetAnnotations()[common.AnnotationKeyTLSConfigHash] !=
-		current.GetAnnotations()[common.AnnotationKeyTLSConfigHash]
-	if !created && (int(incomingGeneration) > currentGeneration || tlsHashChanged) {
+	// update if generation bumped, TLS config changed or the rendered manifest changed
+	tlsHashChanged := annotations[common.AnnotationKeyTLSConfigHash] !=
+		currentAnnotations[common.AnnotationKeyTLSConfigHash]
+	renderedHashChanged := renderedHash != currentAnnotations[common.AnnotationKeyRenderedHash]
+	if !created && (int(incomingGeneration) > currentGeneration || tlsHashChanged || renderedHashChanged) {
 		resource.SetResourceVersion(current.GetResourceVersion())
 		if err := c.Update(context.TODO(), resource); err != nil {
 			if apierrors.IsConflict(err) {
@@ -293,6 +304,15 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 		updated = true
 	}
 	return created, updated, nil
+}
+
+// renderedResourceHash hashes a resource's config fields, i.e. all but metadata and status.
+func renderedResourceHash(resource client.Object) (string, error) {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resource)
+	if err != nil {
+		return "", err
+	}
+	return addonutils.GetSpecHash(&unstructured.Unstructured{Object: content})
 }
 
 func (c *ManagedProxyConfigurationReconciler) getConditions(s *state) []metav1.Condition {

--- a/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
@@ -278,19 +278,21 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 			return false, false, errors.Wrapf(err, "failed reading current generation for %v", gvk.Kind)
 		}
 	}
-	// EXCEPTIONS
-	// short-circuiting for service resources to avoid duplicated cluster-ip assignment
-	if gvk.Group == "" && gvk.Kind == "Service" {
-		return created, false, nil
-	}
-
 	// update if generation bumped, TLS config changed or the rendered manifest changed
 	tlsHashChanged := annotations[common.AnnotationKeyTLSConfigHash] !=
 		currentAnnotations[common.AnnotationKeyTLSConfigHash]
 	renderedHashChanged := renderedHash != currentAnnotations[common.AnnotationKeyRenderedHash]
 	if !created && (int(incomingGeneration) > currentGeneration || tlsHashChanged || renderedHashChanged) {
-		resource.SetResourceVersion(current.GetResourceVersion())
-		if err := c.Update(context.TODO(), resource); err != nil {
+		resourceToUpdate := resource
+		if gvk.Group == "" && gvk.Kind == "Service" {
+			resourceToUpdate, err = serviceForUpdate(resource, current)
+			if err != nil {
+				return false, false, errors.Wrap(err, "failed preparing Service update")
+			}
+		}
+
+		resourceToUpdate.SetResourceVersion(current.GetResourceVersion())
+		if err := c.Update(context.TODO(), resourceToUpdate); err != nil {
 			if apierrors.IsConflict(err) {
 				return c.ensure(incomingGeneration, gvk, resource)
 			}
@@ -304,6 +306,32 @@ func (c *ManagedProxyConfigurationReconciler) ensure(incomingGeneration int64, g
 		updated = true
 	}
 	return created, updated, nil
+}
+
+// serviceForUpdate preserves the network fields assigned by the API server. It mutates a copy so
+// that those cluster-specific values do not become part of the rendered hash on a conflict retry.
+func serviceForUpdate(resource client.Object, current *unstructured.Unstructured) (client.Object, error) {
+	desiredService, ok := resource.DeepCopyObject().(*corev1.Service)
+	if !ok {
+		return nil, fmt.Errorf("expected *corev1.Service, got %T", resource)
+	}
+
+	currentService := &corev1.Service{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(current.Object, currentService); err != nil {
+		return nil, err
+	}
+
+	desiredService.Spec.ClusterIP = currentService.Spec.ClusterIP
+	desiredService.Spec.ClusterIPs = append([]string(nil), currentService.Spec.ClusterIPs...)
+	if len(desiredService.Spec.IPFamilies) == 0 {
+		desiredService.Spec.IPFamilies = append([]corev1.IPFamily(nil), currentService.Spec.IPFamilies...)
+	}
+	if desiredService.Spec.IPFamilyPolicy == nil && currentService.Spec.IPFamilyPolicy != nil {
+		ipFamilyPolicy := *currentService.Spec.IPFamilyPolicy
+		desiredService.Spec.IPFamilyPolicy = &ipFamilyPolicy
+	}
+
+	return desiredService, nil
 }
 
 // renderedResourceHash hashes a resource's config fields, i.e. all but metadata and status.

--- a/pkg/proxyserver/controllers/managedproxyconfiguration_controller_test.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_controller_test.go
@@ -1,0 +1,117 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"open-cluster-management.io/cluster-proxy/pkg/common"
+)
+
+func TestRenderedResourceHashChangesWithRenderedContent(t *testing.T) {
+	config := newTestConfig(3)
+	baseline, err := renderedResourceHash(newProxyServerDeployment(config, "IfNotPresent", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changed := config.DeepCopy()
+	changed.Spec.ProxyServer.Image = "example.invalid/cluster-proxy:new"
+	updated, err := renderedResourceHash(newProxyServerDeployment(changed, "IfNotPresent", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEqual(t, baseline, updated)
+}
+
+func TestRenderedResourceHashChangesWithRoleRules(t *testing.T) {
+	config := newTestConfig(3)
+	baselineRole := newProxyServerRole(config)
+	baseline, err := renderedResourceHash(baselineRole)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changedRole := baselineRole.DeepCopy()
+	changedRole.Rules[0].Verbs = append(changedRole.Rules[0].Verbs, "get")
+	updated, err := renderedResourceHash(changedRole)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEqual(t, baseline, updated)
+}
+
+func TestRenderedResourceHashIgnoresMetadata(t *testing.T) {
+	deploy := newProxyServerDeployment(newTestConfig(3), "IfNotPresent", nil)
+	baseline, err := renderedResourceHash(deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure() stamps these before the conflict retry re-hashes the resource
+	deploy.Annotations[common.AnnotationKeyConfigurationGeneration] = "9"
+	deploy.Annotations[common.AnnotationKeyRenderedHash] = baseline
+	deploy.SetResourceVersion("42")
+
+	stamped, err := renderedResourceHash(deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, baseline, stamped)
+}
+
+func TestEnsureUpdatesRenderedDeploymentWithoutGenerationChange(t *testing.T) {
+	config := newTestConfig(3)
+	config.Name = "cluster-proxy"
+	config.Spec.ProxyServer.Namespace = "proxy-system"
+	config.Spec.ProxyServer.Image = "example.invalid/cluster-proxy:old"
+
+	existing := newProxyServerDeployment(config, "IfNotPresent", nil)
+	existingHash, err := renderedResourceHash(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing.Annotations[common.AnnotationKeyConfigurationGeneration] = "1"
+	existing.Annotations[common.AnnotationKeyRenderedHash] = existingHash
+
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := &ManagedProxyConfigurationReconciler{Client: fakeClient}
+
+	changed := config.DeepCopy()
+	changed.Spec.ProxyServer.Image = "example.invalid/cluster-proxy:new"
+	desired := newProxyServerDeployment(changed, "IfNotPresent", nil)
+	desiredHash, err := renderedResourceHash(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, updated, err := reconciler.ensure(
+		1,
+		appsv1.SchemeGroupVersion.WithKind("Deployment"),
+		desired,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.False(t, created)
+	assert.True(t, updated)
+
+	actual := &appsv1.Deployment{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(existing), actual); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, changed.Spec.ProxyServer.Image, actual.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, desiredHash, actual.Annotations[common.AnnotationKeyRenderedHash])
+}

--- a/pkg/proxyserver/controllers/managedproxyconfiguration_controller_test.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -114,4 +115,68 @@ func TestEnsureUpdatesRenderedDeploymentWithoutGenerationChange(t *testing.T) {
 	}
 	assert.Equal(t, changed.Spec.ProxyServer.Image, actual.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, desiredHash, actual.Annotations[common.AnnotationKeyRenderedHash])
+}
+
+func TestEnsureUpdatesRenderedServiceWithoutGenerationChange(t *testing.T) {
+	config := newTestConfig(3)
+	config.Name = "cluster-proxy"
+	config.Spec.ProxyServer.Namespace = "proxy-system"
+	config.Spec.ProxyServer.InClusterServiceName = "proxy-entrypoint"
+
+	existing := newProxyService(config)
+	existing.Spec.Ports[0].Port = 18090
+	existingHash, err := renderedResourceHash(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing.Annotations = map[string]string{
+		common.AnnotationKeyConfigurationGeneration: "1",
+		common.AnnotationKeyRenderedHash:            existingHash,
+	}
+	existing.Spec.ClusterIP = "10.0.0.42"
+	existing.Spec.ClusterIPs = []string{"10.0.0.42"}
+	existing.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+	ipFamilyPolicy := corev1.IPFamilyPolicySingleStack
+	existing.Spec.IPFamilyPolicy = &ipFamilyPolicy
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := &ManagedProxyConfigurationReconciler{Client: fakeClient}
+
+	desired := newProxyService(config)
+	desiredHash, err := renderedResourceHash(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, updated, err := reconciler.ensure(
+		1,
+		corev1.SchemeGroupVersion.WithKind("Service"),
+		desired,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.False(t, created)
+	assert.True(t, updated)
+
+	actual := &corev1.Service{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(existing), actual); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int32(8090), actual.Spec.Ports[0].Port)
+	assert.Equal(t, existing.Spec.ClusterIP, actual.Spec.ClusterIP)
+	assert.Equal(t, existing.Spec.ClusterIPs, actual.Spec.ClusterIPs)
+	assert.Equal(t, existing.Spec.IPFamilies, actual.Spec.IPFamilies)
+	assert.Equal(t, existing.Spec.IPFamilyPolicy, actual.Spec.IPFamilyPolicy)
+	assert.Equal(t, desiredHash, actual.Annotations[common.AnnotationKeyRenderedHash])
+
+	// API-assigned fields belong only to the update copy, not to the rendered resource.
+	assert.Empty(t, desired.Spec.ClusterIP)
+	assert.Empty(t, desired.Spec.ClusterIPs)
+	assert.Empty(t, desired.Spec.IPFamilies)
+	assert.Nil(t, desired.Spec.IPFamilyPolicy)
 }

--- a/test/integration/controllers/managedproxyconfiguration_controller_test.go
+++ b/test/integration/controllers/managedproxyconfiguration_controller_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
+	"open-cluster-management.io/cluster-proxy/pkg/common"
 )
 
 var _ = Describe("ManagedProxyConfigurationReconciler Test", func() {
@@ -159,6 +160,72 @@ var _ = Describe("ManagedProxyConfigurationReconciler Test", func() {
 					return fmt.Errorf("replicas is not correct, got %d", *deployment.Spec.Replicas)
 				}
 				return err
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should reconcile rendered service changes without replacing allocated network fields", func() {
+			var originalService *corev1.Service
+			Eventually(func() error {
+				service, err := kubeClient.CoreV1().Services(proxyServerNamespace).
+					Get(ctx, "proxy-entrypoint", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if service.Spec.ClusterIP == "" {
+					return fmt.Errorf("service cluster IP is not allocated")
+				}
+				originalService = service.DeepCopy()
+				return nil
+			}, timeout, interval).Should(Succeed())
+
+			staleService := originalService.DeepCopy()
+			staleService.Spec.Ports[0].Port = 18090
+			staleService.Annotations[common.AnnotationKeyRenderedHash] = "stale-render"
+			_, err := kubeClient.CoreV1().Services(proxyServerNamespace).
+				Update(ctx, staleService, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var generation int64
+			Eventually(func() error {
+				currentConfig := &proxyv1alpha1.ManagedProxyConfiguration{}
+				if err := ctrlClient.Get(ctx, client.ObjectKeyFromObject(config), currentConfig); err != nil {
+					return err
+				}
+				generation = currentConfig.Generation
+				if currentConfig.Annotations == nil {
+					currentConfig.Annotations = map[string]string{}
+				}
+				currentConfig.Annotations["proxy.open-cluster-management.io/test-trigger"] = "service-reconcile"
+				return ctrlClient.Update(ctx, currentConfig)
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func() error {
+				service, err := kubeClient.CoreV1().Services(proxyServerNamespace).
+					Get(ctx, "proxy-entrypoint", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if service.Spec.Ports[0].Port != 8090 {
+					return fmt.Errorf("service port is not reconciled, got %d", service.Spec.Ports[0].Port)
+				}
+				if service.Annotations[common.AnnotationKeyRenderedHash] == "stale-render" {
+					return fmt.Errorf("service rendered hash is not reconciled")
+				}
+				if service.Spec.ClusterIP != originalService.Spec.ClusterIP ||
+					!equality.Semantic.DeepEqual(service.Spec.ClusterIPs, originalService.Spec.ClusterIPs) ||
+					!equality.Semantic.DeepEqual(service.Spec.IPFamilies, originalService.Spec.IPFamilies) ||
+					!equality.Semantic.DeepEqual(service.Spec.IPFamilyPolicy, originalService.Spec.IPFamilyPolicy) {
+					return fmt.Errorf("service allocated network fields changed")
+				}
+
+				currentConfig := &proxyv1alpha1.ManagedProxyConfiguration{}
+				if err := ctrlClient.Get(ctx, client.ObjectKeyFromObject(config), currentConfig); err != nil {
+					return err
+				}
+				if currentConfig.Generation != generation {
+					return fmt.Errorf("configuration generation changed from %d to %d", generation, currentConfig.Generation)
+				}
+				return nil
 			}, timeout, interval).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
## What changes

An addon-manager upgrade now brings the updatable resources rendered for the proxy server in line with that manager version, even when the ManagedProxyConfiguration has not changed. Changes to the Deployment, controller-owned in-cluster Service, RBAC, or generated Secret data therefore do not wait for an unrelated configuration or TLS update.

Previously, updates were gated by the ManagedProxyConfiguration generation and TLS configuration. A manager upgrade that changed its rendered output could leave existing resources on the old configuration indefinitely.

In-cluster Service updates preserve the API-assigned cluster IP and IP-family fields. The separately referenced LoadBalancer entrypoint Service keeps its existing create-only behavior.

## Verification

- go test ./pkg/...
- make test-integration
- kind upgrade validation on cpv-hub, cpv-spoke1, and cpv-spoke2: reconciled a stale Service render at the same configuration generation, preserved ClusterIP/IP-family fields, and kept all three cluster-proxy tunnels healthy