### PR TITLE
🐛 fix(proxyserver): watch owned Secrets without duplicate cache

### DIFF
--- a/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,9 +39,12 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ reconcile.Reconciler = &ManagedProxyConfigurationReconciler{}
@@ -79,7 +83,7 @@ func RegisterClusterManagementAddonReconciler(
 		imagePullPolicy:  imagePullPolicy,
 		tlsConfig:        tlsConfig,
 	}
-	return r.SetupWithManager(mgr)
+	return r.SetupWithManager(mgr, secretInformer.Informer())
 }
 
 type ManagedProxyConfigurationReconciler struct {
@@ -97,11 +101,21 @@ type ManagedProxyConfigurationReconciler struct {
 	tlsConfig          *sdktls.TLSConfig
 }
 
-func (c *ManagedProxyConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (c *ManagedProxyConfigurationReconciler) SetupWithManager(mgr ctrl.Manager, secretInformer ctrlcache.Informer) error {
 	// TODO should add a filter to only watch addon with cluster-proxy name
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&proxyv1alpha1.ManagedProxyConfiguration{}).
+		// Reuse the cert rotation informer instead of creating another cluster-wide Secret cache.
+		WatchesRawSource(&source.Informer{
+			Informer: secretInformer,
+			Handler:  managedProxyConfigurationOwnerHandler(mgr.GetScheme(), mgr.GetRESTMapper()),
+		}).
 		Complete(c)
+}
+
+func managedProxyConfigurationOwnerHandler(scheme *runtime.Scheme, mapper meta.RESTMapper) handler.EventHandler {
+	// The generated resources use non-controller owner references, so match every owner reference.
+	return handler.EnqueueRequestForOwner(scheme, mapper, &proxyv1alpha1.ManagedProxyConfiguration{})
 }
 
 func (c *ManagedProxyConfigurationReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/proxyserver/controllers/managedproxyconfiguration_watch_test.go
+++ b/pkg/proxyserver/controllers/managedproxyconfiguration_watch_test.go
@@ -1,0 +1,60 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
+)
+
+func TestManagedProxyConfigurationOwnerHandlerEnqueuesNonControllerOwnerOnSecretUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := proxyv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{proxyv1alpha1.GroupVersion})
+	mapper.Add(proxyv1alpha1.GroupVersion.WithKind("ManagedProxyConfiguration"), meta.RESTScopeRoot)
+
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[reconcile.Request](),
+	)
+	defer queue.ShutDown()
+
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "proxy-system",
+		Name:      "proxy-server-ca",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: proxyv1alpha1.GroupVersion.String(),
+			Kind:       "ManagedProxyConfiguration",
+			Name:       "cluster-proxy",
+		}},
+	}}
+	updatedSecret := secret.DeepCopy()
+	updatedSecret.ResourceVersion = "2"
+	managedProxyConfigurationOwnerHandler(scheme, mapper).Update(
+		context.Background(),
+		event.UpdateEvent{ObjectOld: secret, ObjectNew: updatedSecret},
+		queue,
+	)
+
+	if queue.Len() != 1 {
+		t.Fatalf("expected one request, got %d", queue.Len())
+	}
+	request, shutdown := queue.Get()
+	if shutdown {
+		t.Fatal("workqueue unexpectedly shut down")
+	}
+	defer queue.Done(request)
+	assert.Equal(t, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cluster-proxy"}}, request)
+}


### PR DESCRIPTION
## Summary

Reconcile a `ManagedProxyConfiguration` when one of its owned certificate Secrets changes, using the existing Secret informer.

## Why

Certificate rotation writes new data to Secrets, while certificate conditions and expiry times in `ManagedProxyConfiguration.status` are read through the informer cache. A follow-up reconcile updates the status after the cache observes the new certificate.

Reusing the existing informer also avoids a second cluster-wide Secret cache. A Secret update does not restart proxy-server pods; a rollout still requires a change to the desired Deployment spec.
