### PR TITLE
:bug: CVE-2026-66794: configmap-driven service allowlist for user-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,15 @@ deploy-cluster-proxy-e2e: delete-cluster-proxy-image-from-kind load-cluster-prox
 	--set proxyServer.entrypointAddress="proxy-entrypoint.open-cluster-management-addon.svc" \
 	--set proxyServer.port=8091 \
 	--set enableServiceProxy=true \
-	--set userServer.enabled=true
+	--set userServer.enabled=true \
+	--set 'exposedServices[0].namespace=default' \
+	--set 'exposedServices[0].service=hello-world' \
+	--set 'exposedServices[0].port=8000' \
+	--set 'exposedServices[0].protocol=http' \
+	--set 'exposedServices[1].namespace=default' \
+	--set 'exposedServices[1].service=hello-world-https' \
+	--set 'exposedServices[1].port=8443' \
+	--set 'exposedServices[1].protocol=https'
 	@echo "Cluster-proxy deployed successfully!"
 .PHONY: deploy-cluster-proxy-e2e
 

--- a/charts/cluster-proxy/README.md
+++ b/charts/cluster-proxy/README.md
@@ -41,6 +41,8 @@ helm install cluster-proxy ./charts/cluster-proxy \
 | `featureGates.clusterProfile`           | Enable ClusterProfile integration                                | `false`                                         |
 | `userServer.enabled`                    | Generate and rotate the user-server serving certificate          | `false`                                         |
 | `userServer.additionalSANs`             | Extra SANs for the generated user-server certificate             | `[]`                                            |
+| `exposedServicesConfigMapName`          | ConfigMap containing the service allowlist                        | `cluster-proxy-exposed-services`                 |
+| `exposedServices`                       | Services exposed through the service proxy path                   | `[]`                                            |
 | `networkPolicies.enabled`               | Create opt-in NetworkPolicies for hub and managed workloads       | `false`                                         |
 
 ### Service Proxy and User Server Configuration
@@ -60,6 +62,23 @@ helm install cluster-proxy ./charts/cluster-proxy \
 ```
 
 `enableImpersonation` defaults to true and grants the required hub permissions.
+
+Kubernetes API requests are not filtered by the service allowlist. Requests to
+other Services are denied unless the destination appears in `exposedServices`.
+For example, save the following as `exposed-services.yaml` and pass
+`--values exposed-services.yaml` to the Helm command:
+
+```yaml
+exposedServices:
+  - namespace: monitoring
+    service: prometheus
+    port: "9090"
+    protocol: https
+```
+
+`namespace` and `service` are required. Omit `port` or `protocol` to allow any
+value for that field. To manage the ConfigMap outside Helm, leave
+`exposedServices` empty and set `exposedServicesConfigMapName` to its name.
 
 #### User Server Serving Certificate
 

--- a/charts/cluster-proxy/templates/exposed-services-configmap.yaml
+++ b/charts/cluster-proxy/templates/exposed-services-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.enableServiceProxy .Values.exposedServices }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.exposedServicesConfigMapName | default "cluster-proxy-exposed-services" }}
+  namespace: {{ .Release.Namespace }}
+data:
+  services: |
+{{ toYaml .Values.exposedServices | indent 4 }}
+{{- end }}

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             - --server-cert=/user-tls/tls.crt
             - --service-proxy-ca-cert=/proxy-ca/ca.crt
             - --agent-install-namespace={{ .Values.spokeAddonNamespace }}
+            - --exposed-services-configmap={{ .Values.exposedServicesConfigMapName | default "cluster-proxy-exposed-services" }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -54,6 +54,41 @@ userServer:
   # Example: ["user-server.example.com", "10.0.0.100"]
   additionalSANs: []
 
+# Service proxy allowlist configuration.
+# Controls which services are reachable via the service proxy path in the user-server.
+# The allowlist is enforced by default (default-deny): only services explicitly listed
+# in the ConfigMap are permitted; all others receive 403 Forbidden.
+#
+# exposedServicesConfigMapName: name of the ConfigMap (in the addon namespace) that lists
+#   permitted services. Defaults to "cluster-proxy-exposed-services".
+#
+# exposedServices: when set, a ConfigMap with the above name is created by this Helm chart
+#   containing the listed entries under a key named "services". Each entry requires
+#   'namespace' and 'service'; 'port' and 'protocol' are optional (omit to allow any value).
+#   When managing the ConfigMap manually, any key name(s) may be used — each key's value
+#   is parsed independently and all entries are merged into a single allowlist.
+#
+# Example (Helm-managed, single key):
+#   exposedServices:
+#     - namespace: monitoring
+#       service: prometheus
+#       port: "9090"
+#       protocol: https
+#     - namespace: default
+#       service: my-api
+#       # port/protocol omitted = allow any
+#
+# Example (manually managed ConfigMap with multiple keys):
+#   data:
+#     team-a: |
+#       - namespace: monitoring
+#         service: prometheus
+#     team-b: |
+#       - namespace: default
+#         service: my-api
+exposedServicesConfigMapName: "cluster-proxy-exposed-services"
+# exposedServices: []
+
 # Opt-in NetworkPolicies for hub workloads (addon-manager, user-server, ANP
 # proxy-server) and for the managed-cluster proxy-agent (via manager flag
 # --enable-network-policies). Default false so community installs are unchanged.

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -87,7 +87,7 @@ userServer:
 #       - namespace: default
 #         service: my-api
 exposedServicesConfigMapName: "cluster-proxy-exposed-services"
-# exposedServices: []
+exposedServices: []
 
 # Opt-in NetworkPolicies for hub workloads (addon-manager, user-server, ANP
 # proxy-server) and for the managed-cluster proxy-agent (via manager flag

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -18,4 +18,8 @@ const (
 
 	// UserServerServiceName is the fixed service name for user server.
 	UserServerServiceName = "cluster-proxy-addon-user"
+
+	// ExposedServicesConfigMapName is the default name of the ConfigMap that
+	// controls which services are reachable via the service proxy path.
+	ExposedServicesConfigMapName = "cluster-proxy-exposed-services"
 )

--- a/pkg/serviceproxy/readme.md
+++ b/pkg/serviceproxy/readme.md
@@ -94,6 +94,21 @@ The top-level `enableImpersonation` Helm value grants the required hub
 permissions. The per-cluster `enableImpersonation` variable enables hub token
 authentication in service-proxy and defaults to true.
 
+The command above is enough for Kubernetes API requests. Other Services are
+denied by default. Add each destination to the Helm values when it should be
+reachable through the service proxy path:
+
+```yaml
+exposedServices:
+  - namespace: monitoring
+    service: prometheus
+    port: "9090"
+    protocol: https
+```
+
+See the [Helm chart guide](../../charts/cluster-proxy/README.md#service-proxy-and-user-server-configuration)
+for wildcard fields and manually managed ConfigMaps.
+
 ## OpenShift LDAP hub-token verification
 
 This procedure verifies user, group, and ServiceAccount impersonation across a

--- a/pkg/userserver/service_allowlist.go
+++ b/pkg/userserver/service_allowlist.go
@@ -1,0 +1,123 @@
+package userserver
+
+import (
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/yaml"
+
+	"open-cluster-management.io/cluster-proxy/pkg/utils"
+)
+
+// ExposedService describes a single service that is permitted to be reached
+// via the service proxy path. Namespace and Service are required. Port and
+// Protocol are optional: when omitted (empty string) they act as wildcards
+// and any value in the incoming request will match.
+//
+// Future extension: an optional Clusters []string field can be added here to
+// scope an entry to specific managed clusters. tsc.Cluster is already
+// available in IsAllowed, so the matching logic will naturally support it.
+type ExposedService struct {
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Service   string `json:"service"   yaml:"service"`
+	// Port is optional. When empty, any port is permitted.
+	Port string `json:"port,omitempty" yaml:"port,omitempty"`
+	// Protocol is optional. When empty, any protocol is permitted.
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+}
+
+// matches reports whether this entry permits the given target service config.
+func (e ExposedService) matches(tsc utils.TargetServiceConfig) bool {
+	if e.Namespace != tsc.Namespace {
+		return false
+	}
+	if e.Service != tsc.Service {
+		return false
+	}
+	if e.Port != "" && e.Port != tsc.Port {
+		return false
+	}
+	if e.Protocol != "" && e.Protocol != tsc.Proto {
+		return false
+	}
+	return true
+}
+
+// parseAllExposedServices iterates over every key in a ConfigMap's data map,
+// parses each value as a YAML list of ExposedService entries, and returns the
+// combined slice. Any key name is accepted. If any key's value fails to parse
+// the key name is included in the returned error so operators can locate the
+// problem quickly.
+func parseAllExposedServices(data map[string]string) ([]ExposedService, error) {
+	var all []ExposedService
+	for key, raw := range data {
+		services, err := parseExposedServices(raw)
+		if err != nil {
+			return nil, fmt.Errorf("key %q: %w", key, err)
+		}
+		all = append(all, services...)
+	}
+	return all, nil
+}
+
+// parseExposedServices unmarshals the YAML value stored under any key
+// of the ConfigMap data into a slice of ExposedService entries.
+// It validates that every entry has non-empty Namespace and Service fields.
+func parseExposedServices(data string) ([]ExposedService, error) {
+	if data == "" {
+		return nil, nil
+	}
+	var services []ExposedService
+	if err := yaml.Unmarshal([]byte(data), &services); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal exposed services YAML: %w", err)
+	}
+	for i, svc := range services {
+		if svc.Namespace == "" {
+			return nil, fmt.Errorf("entry[%d]: namespace is required", i)
+		}
+		if svc.Service == "" {
+			return nil, fmt.Errorf("entry[%d]: service is required", i)
+		}
+	}
+	return services, nil
+}
+
+// ServiceAllowlist is a thread-safe, dynamically updatable set of permitted
+// services for the service proxy path. A nil or empty allowlist means no
+// services are permitted (default-deny).
+//
+// Callers obtain a read lock only for the duration of the IsAllowed check, so
+// concurrent HTTP handlers are not serialised against each other.
+type ServiceAllowlist struct {
+	mu       sync.RWMutex
+	services []ExposedService
+}
+
+// update atomically replaces the current allowlist with the supplied entries.
+// Passing nil or an empty slice enforces deny-all.
+func (a *ServiceAllowlist) update(services []ExposedService) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.services = services
+}
+
+// IsAllowed reports whether the given target service config is permitted by
+// the current allowlist. Returns false when the allowlist is empty (deny-all).
+func (a *ServiceAllowlist) IsAllowed(tsc utils.TargetServiceConfig) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, svc := range a.services {
+		if svc.matches(tsc) {
+			return true
+		}
+	}
+	return false
+}
+
+// Len returns the number of entries currently in the allowlist.
+// Primarily useful for logging/diagnostics.
+func (a *ServiceAllowlist) Len() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.services)
+}

--- a/pkg/userserver/service_allowlist.go
+++ b/pkg/userserver/service_allowlist.go
@@ -60,15 +60,15 @@ func parseAllExposedServices(data map[string]string) ([]ExposedService, error) {
 	return all, nil
 }
 
-// parseExposedServices unmarshals the YAML value stored under any key
-// of the ConfigMap data into a slice of ExposedService entries.
-// It validates that every entry has non-empty Namespace and Service fields.
+// parseExposedServices strictly unmarshals the YAML value stored under any key
+// of the ConfigMap data into a slice of ExposedService entries. It validates
+// that every entry has non-empty Namespace and Service fields.
 func parseExposedServices(data string) ([]ExposedService, error) {
 	if data == "" {
 		return nil, nil
 	}
 	var services []ExposedService
-	if err := yaml.Unmarshal([]byte(data), &services); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(data), &services); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal exposed services YAML: %w", err)
 	}
 	for i, svc := range services {

--- a/pkg/userserver/service_allowlist.go
+++ b/pkg/userserver/service_allowlist.go
@@ -87,7 +87,7 @@ func parseExposedServices(data string) ([]ExposedService, error) {
 // services are permitted (default-deny).
 //
 // Callers obtain a read lock only for the duration of the IsAllowed check, so
-// concurrent HTTP handlers are not serialised against each other.
+// concurrent HTTP handlers are not serialized against each other.
 type ServiceAllowlist struct {
 	mu       sync.RWMutex
 	services []ExposedService

--- a/pkg/userserver/service_allowlist_test.go
+++ b/pkg/userserver/service_allowlist_test.go
@@ -1,0 +1,343 @@
+package userserver
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"open-cluster-management.io/cluster-proxy/pkg/utils"
+)
+
+// ---------------------------------------------------------------------------
+// parseAllExposedServices
+// ---------------------------------------------------------------------------
+
+func TestParseAllExposedServices_SingleKey(t *testing.T) {
+	data := map[string]string{
+		"services": `
+- namespace: monitoring
+  service: prometheus
+  port: "9090"
+`,
+	}
+	services, err := parseAllExposedServices(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Namespace != "monitoring" || services[0].Service != "prometheus" {
+		t.Errorf("unexpected service: %+v", services[0])
+	}
+}
+
+func TestParseAllExposedServices_MultipleKeys(t *testing.T) {
+	data := map[string]string{
+		"team-a": `
+- namespace: monitoring
+  service: prometheus
+`,
+		"team-b": `
+- namespace: default
+  service: my-api
+- namespace: default
+  service: other-api
+`,
+	}
+	services, err := parseAllExposedServices(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 3 {
+		t.Fatalf("expected 3 services, got %d", len(services))
+	}
+}
+
+func TestParseAllExposedServices_EmptyMap(t *testing.T) {
+	services, err := parseAllExposedServices(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(services))
+	}
+}
+
+func TestParseAllExposedServices_EmptyKeyValue(t *testing.T) {
+	data := map[string]string{
+		"empty-key": "",
+		"real-key": `
+- namespace: monitoring
+  service: prometheus
+`,
+	}
+	services, err := parseAllExposedServices(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service (empty key skipped), got %d", len(services))
+	}
+}
+
+func TestParseAllExposedServices_InvalidKey_ReturnsErrorWithKeyName(t *testing.T) {
+	data := map[string]string{
+		"bad-key": "this: is: not: valid: yaml: [[[",
+	}
+	_, err := parseAllExposedServices(data)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-key") {
+		t.Errorf("expected error to contain key name %q, got: %v", "bad-key", err)
+	}
+}
+
+func TestParseAllExposedServices_MissingNamespace_ReturnsErrorWithKeyName(t *testing.T) {
+	data := map[string]string{
+		"problem-key": `
+- service: prometheus
+`,
+	}
+	_, err := parseAllExposedServices(data)
+	if err == nil {
+		t.Fatal("expected error for missing namespace, got nil")
+	}
+	if !strings.Contains(err.Error(), "problem-key") {
+		t.Errorf("expected error to contain key name %q, got: %v", "problem-key", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseExposedServices
+// ---------------------------------------------------------------------------
+
+func TestParseExposedServices_Valid(t *testing.T) {
+	yaml := `
+- namespace: monitoring
+  service: prometheus
+  port: "9090"
+  protocol: https
+- namespace: default
+  service: my-api
+`
+	services, err := parseExposedServices(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(services))
+	}
+
+	if services[0].Namespace != "monitoring" || services[0].Service != "prometheus" ||
+		services[0].Port != "9090" || services[0].Protocol != "https" {
+		t.Errorf("services[0] mismatch: %+v", services[0])
+	}
+	if services[1].Namespace != "default" || services[1].Service != "my-api" ||
+		services[1].Port != "" || services[1].Protocol != "" {
+		t.Errorf("services[1] mismatch: %+v", services[1])
+	}
+}
+
+func TestParseExposedServices_Empty(t *testing.T) {
+	services, err := parseExposedServices("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(services))
+	}
+}
+
+func TestParseExposedServices_MissingNamespace(t *testing.T) {
+	yaml := `
+- service: prometheus
+  port: "9090"
+`
+	_, err := parseExposedServices(yaml)
+	if err == nil {
+		t.Fatal("expected error for missing namespace, got nil")
+	}
+}
+
+func TestParseExposedServices_MissingService(t *testing.T) {
+	yaml := `
+- namespace: monitoring
+  port: "9090"
+`
+	_, err := parseExposedServices(yaml)
+	if err == nil {
+		t.Fatal("expected error for missing service, got nil")
+	}
+}
+
+func TestParseExposedServices_MalformedYAML(t *testing.T) {
+	_, err := parseExposedServices("this: is: not: valid: yaml: [[[")
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExposedService.matches
+// ---------------------------------------------------------------------------
+
+func TestMatches_ExactMatch(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus", Port: "9090", Protocol: "https"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "https"}
+	if !e.matches(tsc) {
+		t.Error("expected match")
+	}
+}
+
+func TestMatches_WildcardPort(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "https"}
+	if !e.matches(tsc) {
+		t.Error("expected match when port is omitted")
+	}
+}
+
+func TestMatches_WildcardProtocol(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus", Port: "9090"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "http"}
+	if !e.matches(tsc) {
+		t.Error("expected match when protocol is omitted")
+	}
+}
+
+func TestMatches_WrongNamespace(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus"}
+	tsc := utils.TargetServiceConfig{Namespace: "other", Service: "prometheus", Port: "9090", Proto: "https"}
+	if e.matches(tsc) {
+		t.Error("expected no match for wrong namespace")
+	}
+}
+
+func TestMatches_WrongService(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "grafana", Port: "3000", Proto: "https"}
+	if e.matches(tsc) {
+		t.Error("expected no match for wrong service")
+	}
+}
+
+func TestMatches_WrongPort(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus", Port: "9090"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "8080", Proto: "https"}
+	if e.matches(tsc) {
+		t.Error("expected no match for wrong port")
+	}
+}
+
+func TestMatches_WrongProtocol(t *testing.T) {
+	e := ExposedService{Namespace: "monitoring", Service: "prometheus", Protocol: "https"}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "http"}
+	if e.matches(tsc) {
+		t.Error("expected no match for wrong protocol")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ServiceAllowlist.IsAllowed
+// ---------------------------------------------------------------------------
+
+func TestIsAllowed_EmptyList_DeniesAll(t *testing.T) {
+	a := &ServiceAllowlist{}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "https"}
+	if a.IsAllowed(tsc) {
+		t.Error("empty allowlist should deny all requests")
+	}
+}
+
+func TestIsAllowed_MatchingEntry(t *testing.T) {
+	a := &ServiceAllowlist{
+		services: []ExposedService{
+			{Namespace: "monitoring", Service: "prometheus", Port: "9090", Protocol: "https"},
+		},
+	}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "https"}
+	if !a.IsAllowed(tsc) {
+		t.Error("expected request to be allowed")
+	}
+}
+
+func TestIsAllowed_NoMatchingEntry(t *testing.T) {
+	a := &ServiceAllowlist{
+		services: []ExposedService{
+			{Namespace: "monitoring", Service: "prometheus"},
+		},
+	}
+	tsc := utils.TargetServiceConfig{Namespace: "default", Service: "other-service", Port: "8080", Proto: "http"}
+	if a.IsAllowed(tsc) {
+		t.Error("expected request to be denied")
+	}
+}
+
+func TestIsAllowed_MultipleEntries_FirstMatches(t *testing.T) {
+	a := &ServiceAllowlist{
+		services: []ExposedService{
+			{Namespace: "monitoring", Service: "prometheus"},
+			{Namespace: "default", Service: "my-api"},
+		},
+	}
+	tsc := utils.TargetServiceConfig{Namespace: "monitoring", Service: "prometheus", Port: "9090", Proto: "https"}
+	if !a.IsAllowed(tsc) {
+		t.Error("expected request to be allowed by first entry")
+	}
+}
+
+func TestIsAllowed_MultipleEntries_SecondMatches(t *testing.T) {
+	a := &ServiceAllowlist{
+		services: []ExposedService{
+			{Namespace: "monitoring", Service: "prometheus"},
+			{Namespace: "default", Service: "my-api"},
+		},
+	}
+	tsc := utils.TargetServiceConfig{Namespace: "default", Service: "my-api", Port: "8080", Proto: "http"}
+	if !a.IsAllowed(tsc) {
+		t.Error("expected request to be allowed by second entry")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ServiceAllowlist thread-safety
+// ---------------------------------------------------------------------------
+
+func TestServiceAllowlist_ConcurrentReadWrite(t *testing.T) {
+	a := &ServiceAllowlist{}
+	tsc := utils.TargetServiceConfig{Namespace: "ns", Service: "svc", Port: "80", Proto: "http"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			a.IsAllowed(tsc)
+		}()
+		go func() {
+			defer wg.Done()
+			a.update([]ExposedService{{Namespace: "ns", Service: "svc"}})
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// ServiceAllowlist.update (keeps last-known-good on nil)
+// ---------------------------------------------------------------------------
+
+func TestServiceAllowlist_UpdateNilClearsList(t *testing.T) {
+	a := &ServiceAllowlist{
+		services: []ExposedService{{Namespace: "ns", Service: "svc"}},
+	}
+	a.update(nil)
+	if a.Len() != 0 {
+		t.Errorf("expected 0 entries after update(nil), got %d", a.Len())
+	}
+	tsc := utils.TargetServiceConfig{Namespace: "ns", Service: "svc"}
+	if a.IsAllowed(tsc) {
+		t.Error("expected deny-all after update(nil)")
+	}
+}

--- a/pkg/userserver/service_allowlist_test.go
+++ b/pkg/userserver/service_allowlist_test.go
@@ -140,6 +140,54 @@ func TestParseExposedServices_Valid(t *testing.T) {
 	}
 }
 
+func TestParseExposedServices_NumericPort(t *testing.T) {
+	yaml := `
+- namespace: monitoring
+  service: prometheus
+  port: 9090
+  protocol: https
+`
+	services, err := parseExposedServices(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Port != "9090" {
+		t.Errorf("expected numeric port to be parsed as a string, got %q", services[0].Port)
+	}
+}
+
+func TestParseExposedServices_UnknownField(t *testing.T) {
+	yaml := `
+- namespace: monitoring
+  service: prometheus
+  port: "9090"
+  protcol: https
+`
+	_, err := parseExposedServices(yaml)
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	if !strings.Contains(err.Error(), "protcol") {
+		t.Errorf("expected error to contain unknown field name %q, got: %v", "protcol", err)
+	}
+}
+
+func TestParseExposedServices_DuplicateField(t *testing.T) {
+	yaml := `
+- namespace: monitoring
+  service: prometheus
+  port: "9090"
+  port: "9443"
+`
+	_, err := parseExposedServices(yaml)
+	if err == nil {
+		t.Fatal("expected error for duplicate field, got nil")
+	}
+}
+
 func TestParseExposedServices_Empty(t *testing.T) {
 	services, err := parseExposedServices("")
 	if err != nil {

--- a/pkg/userserver/service_allowlist_watcher.go
+++ b/pkg/userserver/service_allowlist_watcher.go
@@ -17,7 +17,7 @@ import (
 // startServiceAllowlistWatcher creates a namespace-scoped ConfigMap informer
 // that keeps the returned ServiceAllowlist up to date whenever the named
 // ConfigMap changes. It blocks until the informer cache is synced, then
-// returns with the watcher running in the background until ctx is cancelled.
+// returns with the watcher running in the background until ctx is canceled.
 //
 // On Add/Update: the YAML under each key is parsed and combined into a single
 // allowlist that is atomically replaced. Any key name is accepted. If any key's

--- a/pkg/userserver/service_allowlist_watcher.go
+++ b/pkg/userserver/service_allowlist_watcher.go
@@ -1,0 +1,101 @@
+package userserver
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// startServiceAllowlistWatcher creates a namespace-scoped ConfigMap informer
+// that keeps the returned ServiceAllowlist up to date whenever the named
+// ConfigMap changes. It blocks until the informer cache is synced, then
+// returns with the watcher running in the background until ctx is cancelled.
+//
+// On Add/Update: the YAML under each key is parsed and combined into a single
+// allowlist that is atomically replaced. Any key name is accepted. If any key's
+// YAML is invalid the last-known-good list is preserved and an error is logged.
+//
+// On Delete: the allowlist is set to empty (deny-all).
+func startServiceAllowlistWatcher(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	configMapName string,
+) (*ServiceAllowlist, error) {
+	allowlist := &ServiceAllowlist{}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		10*time.Minute,
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", configMapName).String()
+		}),
+	)
+
+	cmInformer := informerFactory.Core().V1().ConfigMaps().Informer()
+
+	// updateFromConfigMap parses the ConfigMap and updates the allowlist.
+	// On parse error the existing allowlist is preserved.
+	updateFromConfigMap := func(cm *corev1.ConfigMap) {
+		services, err := parseAllExposedServices(cm.Data)
+		if err != nil {
+			klog.Errorf("service allowlist: failed to parse ConfigMap %s/%s, keeping last-known-good list: %v",
+				namespace, configMapName, err)
+			return
+		}
+		allowlist.update(services)
+		klog.V(2).Infof("service allowlist: loaded %d entries from ConfigMap %s/%s",
+			len(services), namespace, configMapName)
+	}
+
+	if _, err := cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			updateFromConfigMap(cm)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			cm, ok := newObj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+			updateFromConfigMap(cm)
+		},
+		DeleteFunc: func(_ interface{}) {
+			allowlist.update(nil)
+			klog.V(2).Infof("service allowlist: ConfigMap %s/%s deleted, all service proxy requests will be denied",
+				namespace, configMapName)
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	informerFactory.Start(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), cmInformer.HasSynced) {
+		return nil, ctx.Err()
+	}
+
+	// The informer's Add event fires during the list phase (before
+	// WaitForCacheSync returns), so by the time we reach here the allowlist
+	// already reflects the current ConfigMap state. Log a warning if the
+	// ConfigMap was not found so operators know the deny-all default is active.
+	lister := informerFactory.Core().V1().ConfigMaps().Lister()
+	if _, err := lister.ConfigMaps(namespace).Get(configMapName); errors.IsNotFound(err) {
+		klog.Warningf("service allowlist: ConfigMap %s/%s not found at startup — all service proxy requests will be denied until it is created",
+			namespace, configMapName)
+	}
+
+	return allowlist, nil
+}

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -72,6 +72,14 @@ type userServer struct {
 	drain                  utils.DrainConfig
 
 	addonLister addonlisterv1beta1.ManagedClusterAddOnLister
+
+	// exposedServicesConfigMap is the name of the ConfigMap (in the pod's own
+	// namespace) that lists permitted service proxy targets. Defaults to the
+	// well-known constant ExposedServicesConfigMapName.
+	exposedServicesConfigMap string
+	// serviceAllowlist is populated at startup from the ConfigMap and kept
+	// up to date by an informer.
+	serviceAllowlist *ServiceAllowlist
 }
 
 func (k *userServer) AddFlags(cmd *cobra.Command) {
@@ -92,6 +100,9 @@ func (k *userServer) AddFlags(cmd *cobra.Command) {
 
 	flags.StringVar(&k.agentInstallNamespace, "agent-install-namespace", k.agentInstallNamespace, "The namespace of the agent install")
 	k.drain.AddFlags(flags)
+
+	flags.StringVar(&k.exposedServicesConfigMap, "exposed-services-configmap", constant.ExposedServicesConfigMapName,
+		"Name of the ConfigMap (in the pod's namespace) that lists which services are reachable via the service proxy path")
 }
 
 func (k *userServer) Validate() error {
@@ -122,7 +133,7 @@ func newUserServer() *userServer {
 	return &userServer{}
 }
 
-func (k *userServer) init(ctx context.Context) error {
+func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, podNamespace string) error {
 	proxyTLSCfg, err := util.GetClientTLSConfig(k.proxyCACertPath, k.proxyCertPath, k.proxyKeyPath, k.proxyServerHost, nil)
 	if err != nil {
 		return err
@@ -163,6 +174,16 @@ func (k *userServer) init(ctx context.Context) error {
 	k.addonLister = addonInformerFactory.Addon().V1beta1().ManagedClusterAddOns().Lister()
 	addonInformerFactory.Start(ctx.Done())
 
+	// Start the service allowlist watcher. The watcher enforces default-deny:
+	// only services listed in the ConfigMap are reachable via the service proxy
+	// path. Kube-apiserver proxy requests are not subject to this check.
+	k.serviceAllowlist, err = startServiceAllowlistWatcher(ctx, kubeClient, podNamespace, k.exposedServicesConfigMap)
+	if err != nil {
+		return fmt.Errorf("failed to start service allowlist watcher: %w", err)
+	}
+	klog.Infof("service allowlist active: %d entries loaded from ConfigMap %s/%s",
+		k.serviceAllowlist.Len(), podNamespace, k.exposedServicesConfigMap)
+
 	return nil
 }
 
@@ -182,12 +203,24 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	switch utils.GetProxyType(req.RequestURI) {
 	case utils.ProxyTypeService:
 		tsc, err = utils.GetTargetServiceConfig(req.RequestURI)
+		if err != nil {
+			http.Error(wr, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !k.serviceAllowlist.IsAllowed(tsc) {
+			klog.V(4).Infof("service proxy request denied: %s/%s is not in the exposed services allowlist",
+				tsc.Namespace, tsc.Service)
+			http.Error(wr,
+				fmt.Sprintf("service %s/%s is not in the exposed services allowlist", tsc.Namespace, tsc.Service),
+				http.StatusForbidden)
+			return
+		}
 	case utils.ProxyTypeKubeAPIServer:
 		tsc, err = utils.GetTargetServiceConfigForKubeAPIServer(req.RequestURI)
-	}
-	if err != nil {
-		http.Error(wr, err.Error(), http.StatusBadRequest)
-		return
+		if err != nil {
+			http.Error(wr, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	targetURL, err := url.Parse(serviceProxyURL(tsc.Cluster))
@@ -245,23 +278,26 @@ func (k *userServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err = k.init(runCtx); err != nil {
-		return err
-	}
-
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if len(podNamespace) == 0 {
 		return fmt.Errorf("pod namespace is empty, please set the POD_NAMESPACE environment variable")
 	}
 
+	// Create the kube client once and share it between init (service allowlist
+	// watcher) and the TLS ConfigMap watcher so we only open one connection.
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		return fmt.Errorf("failed to get Kubernetes config for TLS watcher: %w", err)
+		return fmt.Errorf("failed to get Kubernetes config: %w", err)
 	}
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create kube client for TLS watcher: %w", err)
+		return fmt.Errorf("failed to create kube client: %w", err)
 	}
+
+	if err = k.init(runCtx, kubeClient, podNamespace); err != nil {
+		return err
+	}
+
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, kubeClient, podNamespace, func() {
 		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")
 		cancel()


### PR DESCRIPTION
Add a ConfigMap-based allowlist that controls which services are
reachable via the service proxy path in the user-server.

Design:
- Default-deny: only services explicitly listed in the ConfigMap
  are permitted; all others get 403 Forbidden.
- Kube-apiserver proxy requests are not subject to allowlist filtering.
- Uses a k8s SharedInformerFactory (namespace-scoped, field-selector
  filtered) to watch the ConfigMap and update the in-memory allowlist
  without requiring a pod restart.
- On parse error the last-known-good list is preserved.
- On ConfigMap deletion the allowlist is set to empty (deny-all).
- Any key name in the ConfigMap data is accepted; all entries are
  merged into a single allowlist.

New flag on the user-server:
  --exposed-services-configmap  name of the ConfigMap to watch
                                (default: cluster-proxy-exposed-services)

Signed-off-by: Tesshu Flower <tflower@redhat.com>