### PR TITLE
:seedling: chore: dynamically fetch Go version in workflows

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -8,9 +8,6 @@ on:
     types: [published]
 
 env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: 'cluster-proxy'
 

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -10,11 +10,6 @@ on:
       - release-*
   workflow_dispatch: {}
 
-env:
-  # Common versions
-  GO_VERSION: "1.26"
-  GO_REQUIRED_MIN_VERSION: ""
-
 jobs:
   images:
     name: images
@@ -31,7 +26,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -14,11 +14,6 @@ on:
       - main
       - release-*
 
-env:
-  # Common versions
-  GO_VERSION: "1.26"
-  GO_REQUIRED_MIN_VERSION: ""
-
 jobs:
   build:
     name: build
@@ -31,7 +26,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: build
         run: make build
@@ -46,7 +41,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: verify
         run: make verify
@@ -64,7 +59,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: setup helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -84,7 +79,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: unit
         run: make test
@@ -109,7 +104,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: integration
         run: make test-integration
@@ -125,7 +120,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: setup helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -8,9 +8,6 @@ on:
     tags:
       - "v*.*.*"
 env:
-  # Common versions
-  GO_VERSION: "1.26"
-  GO_REQUIRED_MIN_VERSION: ""
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: "cluster-proxy"
 
@@ -54,7 +51,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3


### PR DESCRIPTION
Currently the GitHub workflows rely on a static value for the Go version. It's more maintainable to specify that Go be fetched from the `go.mod` instead.