### PR TITLE
:bug: bug: fix user-server tunnel churn causing proxy-server saturation under load

### DIFF
--- a/charts/cluster-proxy/README.md
+++ b/charts/cluster-proxy/README.md
@@ -40,6 +40,7 @@ helm install cluster-proxy ./charts/cluster-proxy \
 | `enableImpersonation`                   | Grant permissions for hub token authentication                    | `true`                                          |
 | `featureGates.clusterProfile`           | Enable ClusterProfile integration                                | `false`                                         |
 | `userServer.enabled`                    | Generate and rotate the user-server serving certificate          | `false`                                         |
+| `userServer.enableHTTP2`                | Multiplex non-upgrade requests over reusable HTTP/2 tunnels       | `true`                                          |
 | `userServer.additionalSANs`             | Extra SANs for the generated user-server certificate             | `[]`                                            |
 | `exposedServicesConfigMapName`          | ConfigMap containing the service allowlist                        | `cluster-proxy-exposed-services`                 |
 | `exposedServices`                       | Services exposed through the service proxy path                   | `[]`                                            |

--- a/charts/cluster-proxy/templates/user-deployment.yaml
+++ b/charts/cluster-proxy/templates/user-deployment.yaml
@@ -64,6 +64,7 @@ spec:
             - --service-proxy-ca-cert=/proxy-ca/ca.crt
             - --agent-install-namespace={{ .Values.spokeAddonNamespace }}
             - --exposed-services-configmap={{ .Values.exposedServicesConfigMapName | default "cluster-proxy-exposed-services" }}
+            - --enable-http2={{ .Values.userServer.enableHTTP2 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/charts/cluster-proxy/values.yaml
+++ b/charts/cluster-proxy/values.yaml
@@ -50,6 +50,8 @@ featureGates:
 userServer:
   # Enable automatic certificate rotation for user server
   enabled: false
+  # Enable HTTP/2 for user-server connections to managed clusters.
+  enableHTTP2: true
   # Additional SANs for the certificate (e.g., external hostnames)
   # Example: ["user-server.example.com", "10.0.0.100"]
   additionalSANs: []

--- a/pkg/userserver/transport_pool.go
+++ b/pkg/userserver/transport_pool.go
@@ -1,0 +1,179 @@
+package userserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+
+	"open-cluster-management.io/cluster-proxy/pkg/constant"
+)
+
+const managedClusterAddonResyncPeriod = 30 * time.Minute
+
+// clusterTransportPool owns the reusable transports for managed clusters where
+// the cluster-proxy add-on is installed. Membership changes and transport
+// creation use the same exclusive lock so an informer delete cannot race with
+// creation of a new cached transport. Cache hits use the shared side of the lock.
+type clusterTransportPool struct {
+	mu           sync.RWMutex
+	allowed      map[string]struct{}
+	transports   map[string]*http.Transport
+	newTransport func(clusterName string) *http.Transport
+}
+
+func newClusterTransportPool(newTransport func(clusterName string) *http.Transport) *clusterTransportPool {
+	return &clusterTransportPool{
+		allowed:      map[string]struct{}{},
+		transports:   map[string]*http.Transport{},
+		newTransport: newTransport,
+	}
+}
+
+func (p *clusterTransportPool) allow(clusterName string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.allowed[clusterName] = struct{}{}
+}
+
+func (p *clusterTransportPool) getOrCreate(clusterName string) (*http.Transport, bool) {
+	p.mu.RLock()
+	_, allowed := p.allowed[clusterName]
+	transport, cached := p.transports[clusterName]
+	p.mu.RUnlock()
+
+	if !allowed {
+		return nil, false
+	}
+	if cached {
+		return transport, true
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.allowed[clusterName]; !ok {
+		return nil, false
+	}
+	if transport, ok := p.transports[clusterName]; ok {
+		return transport, true
+	}
+
+	transport = p.newTransport(clusterName)
+	p.transports[clusterName] = transport
+	return transport, true
+}
+
+func (p *clusterTransportPool) isAllowed(clusterName string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	_, ok := p.allowed[clusterName]
+	return ok
+}
+
+func (p *clusterTransportPool) remove(clusterName string) {
+	p.mu.Lock()
+	delete(p.allowed, clusterName)
+	transport := p.transports[clusterName]
+	delete(p.transports, clusterName)
+	p.mu.Unlock()
+
+	if transport != nil {
+		transport.CloseIdleConnections()
+	}
+}
+
+func (p *clusterTransportPool) closeAll() {
+	p.mu.Lock()
+	clear(p.allowed)
+	transports := p.transports
+	p.transports = map[string]*http.Transport{}
+	p.mu.Unlock()
+
+	for _, transport := range transports {
+		transport.CloseIdleConnections()
+	}
+}
+
+// startManagedClusterAddonWatcher keeps the transport pool membership aligned
+// with ManagedClusterAddOn/cluster-proxy resources and waits for the initial
+// list before returning. Until that list is complete, the user-server must not
+// accept requests because the pool intentionally defaults to denying access.
+func startManagedClusterAddonWatcher(
+	ctx context.Context,
+	client addonclient.Interface,
+	pool *clusterTransportPool,
+) error {
+	informerFactory := addoninformers.NewSharedInformerFactoryWithOptions(
+		client,
+		managedClusterAddonResyncPeriod,
+		addoninformers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", constant.AddonName).String()
+		}),
+	)
+	informer := informerFactory.Addon().V1beta1().ManagedClusterAddOns().Informer()
+
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if addon, ok := clusterProxyAddon(obj); ok {
+				pool.allow(addon.Namespace)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			if addon, ok := clusterProxyAddon(newObj); ok {
+				pool.allow(addon.Namespace)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if addon, ok := deletedClusterProxyAddon(obj); ok {
+				pool.remove(addon.Namespace)
+			}
+		},
+	}); err != nil {
+		return fmt.Errorf("register managed cluster add-on event handler: %w", err)
+	}
+
+	informerFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return fmt.Errorf("managed cluster add-on informer cache did not sync")
+	}
+
+	return nil
+}
+
+func clusterProxyAddon(obj interface{}) (*addonv1beta1.ManagedClusterAddOn, bool) {
+	addon, ok := obj.(*addonv1beta1.ManagedClusterAddOn)
+	return addon, ok && addon.Name == constant.AddonName && addon.Namespace != ""
+}
+
+func deletedClusterProxyAddon(obj interface{}) (*addonv1beta1.ManagedClusterAddOn, bool) {
+	if addon, ok := clusterProxyAddon(obj); ok {
+		return addon, true
+	}
+
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		klog.Errorf("transport pool: unexpected managed cluster add-on delete object %T", obj)
+		return nil, false
+	}
+	addon, ok := clusterProxyAddon(tombstone.Obj)
+	if !ok {
+		klog.Errorf("transport pool: unexpected managed cluster add-on tombstone object %T", tombstone.Obj)
+	}
+	return addon, ok
+}

--- a/pkg/userserver/transport_pool_test.go
+++ b/pkg/userserver/transport_pool_test.go
@@ -1,0 +1,266 @@
+package userserver
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
+
+	"open-cluster-management.io/cluster-proxy/pkg/constant"
+)
+
+func TestClusterTransportPool(t *testing.T) {
+	var created atomic.Int64
+	pool := newClusterTransportPool(func(string) *http.Transport {
+		created.Add(1)
+		return &http.Transport{}
+	})
+
+	if _, ok := pool.getOrCreate("cluster1"); ok {
+		t.Fatal("an unknown cluster must not get a transport")
+	}
+
+	pool.allow("cluster1")
+	first, ok := pool.getOrCreate("cluster1")
+	if !ok {
+		t.Fatal("an allowed cluster must get a transport")
+	}
+	second, ok := pool.getOrCreate("cluster1")
+	if !ok || second != first {
+		t.Fatal("the same cluster must reuse its transport")
+	}
+
+	pool.allow("cluster2")
+	other, ok := pool.getOrCreate("cluster2")
+	if !ok || other == first {
+		t.Fatal("different clusters must use different transports")
+	}
+	if got := created.Load(); got != 2 {
+		t.Fatalf("created %d transports, want 2", got)
+	}
+
+	pool.remove("cluster1")
+	if _, ok := pool.getOrCreate("cluster1"); ok {
+		t.Fatal("a removed cluster must not get a transport")
+	}
+
+	pool.allow("cluster1")
+	readded, ok := pool.getOrCreate("cluster1")
+	if !ok || readded == first {
+		t.Fatal("a re-added cluster must get a fresh transport")
+	}
+}
+
+func TestClusterTransportPoolConcurrentGetOrCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		warmCache bool
+	}{
+		{name: "cold cache"},
+		{name: "warm cache", warmCache: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var created atomic.Int64
+			pool := newClusterTransportPool(func(string) *http.Transport {
+				created.Add(1)
+				return &http.Transport{}
+			})
+			pool.allow("cluster1")
+			if test.warmCache {
+				pool.getOrCreate("cluster1")
+			}
+
+			const goroutines = 64
+			results := make([]*http.Transport, goroutines)
+			var wg sync.WaitGroup
+			for i := range results {
+				wg.Add(1)
+				go func(index int) {
+					defer wg.Done()
+					results[index], _ = pool.getOrCreate("cluster1")
+				}(i)
+			}
+			wg.Wait()
+
+			for i, result := range results {
+				if result != results[0] {
+					t.Fatalf("goroutine %d received a different transport", i)
+				}
+			}
+			if got := created.Load(); got != 1 {
+				t.Fatalf("created %d transports, want 1", got)
+			}
+		})
+	}
+}
+
+func TestClusterTransportPoolRemoveWinsFinalRace(t *testing.T) {
+	pool := newClusterTransportPool(func(string) *http.Transport { return &http.Transport{} })
+	pool.allow("cluster1")
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			pool.allow("cluster1")
+			_, _ = pool.getOrCreate("cluster1")
+		}()
+		go func() {
+			defer wg.Done()
+			pool.remove("cluster1")
+		}()
+	}
+	wg.Wait()
+
+	pool.remove("cluster1")
+	if _, ok := pool.getOrCreate("cluster1"); ok {
+		t.Fatal("the final remove must prevent a later transport creation")
+	}
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	if _, ok := pool.transports["cluster1"]; ok {
+		t.Fatal("the final remove left a cached transport")
+	}
+}
+
+func TestClusterTransportPoolClosesIdleConnections(t *testing.T) {
+	tests := map[string]func(*clusterTransportPool){
+		"remove": func(pool *clusterTransportPool) { pool.remove("cluster1") },
+		"close":  func(pool *clusterTransportPool) { pool.closeAll() },
+	}
+
+	for name, closePool := range tests {
+		t.Run(name, func(t *testing.T) {
+			idle := make(chan struct{})
+			closed := make(chan struct{})
+			var idleOnce sync.Once
+			var closedOnce sync.Once
+			backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, "ok")
+			}))
+			backend.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				switch state {
+				case http.StateIdle:
+					idleOnce.Do(func() { close(idle) })
+				case http.StateClosed:
+					closedOnce.Do(func() { close(closed) })
+				}
+			}
+			backend.Start()
+			t.Cleanup(backend.Close)
+
+			pool := newClusterTransportPool(func(string) *http.Transport { return &http.Transport{} })
+			pool.allow("cluster1")
+			transport, _ := pool.getOrCreate("cluster1")
+			response, err := transport.RoundTrip(mustRequest(t, backend.URL))
+			if err != nil {
+				t.Fatalf("round trip: %v", err)
+			}
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+			waitForSignal(t, idle, "backend connection to become idle")
+
+			closePool(pool)
+			waitForSignal(t, closed, "idle backend connection to close")
+			if pool.isAllowed("cluster1") {
+				t.Fatal("closed pool still allows cluster1")
+			}
+		})
+	}
+}
+
+func TestStartManagedClusterAddonWatcher(t *testing.T) {
+	cluster1Addon := newManagedClusterAddon("cluster1", constant.AddonName)
+	unrelatedAddon := newManagedClusterAddon("cluster2", "other-addon")
+	client := fakeaddon.NewSimpleClientset(cluster1Addon, unrelatedAddon)
+	pool := newClusterTransportPool(func(string) *http.Transport { return &http.Transport{} })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := startManagedClusterAddonWatcher(ctx, client, pool); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	if !pool.isAllowed("cluster1") {
+		t.Fatal("initial informer list did not allow cluster1")
+	}
+	if pool.isAllowed("cluster2") {
+		t.Fatal("an unrelated add-on must not allow cluster2")
+	}
+
+	cluster3Addon := newManagedClusterAddon("cluster3", constant.AddonName)
+	if _, err := client.AddonV1beta1().ManagedClusterAddOns("cluster3").Create(
+		ctx, cluster3Addon, metav1.CreateOptions{},
+	); err != nil {
+		t.Fatalf("create add-on: %v", err)
+	}
+	waitForCondition(t, func() bool { return pool.isAllowed("cluster3") }, "cluster3 to become allowed")
+
+	pool.getOrCreate("cluster1")
+	if err := client.AddonV1beta1().ManagedClusterAddOns("cluster1").Delete(
+		ctx, constant.AddonName, metav1.DeleteOptions{},
+	); err != nil {
+		t.Fatalf("delete add-on: %v", err)
+	}
+	waitForCondition(t, func() bool { return !pool.isAllowed("cluster1") }, "cluster1 to become disallowed")
+	pool.mu.Lock()
+	_, cached := pool.transports["cluster1"]
+	pool.mu.Unlock()
+	if cached {
+		t.Fatal("add-on deletion did not evict the cluster1 transport")
+	}
+}
+
+func TestDeletedClusterProxyAddonTombstone(t *testing.T) {
+	want := newManagedClusterAddon("cluster1", constant.AddonName)
+	got, ok := deletedClusterProxyAddon(cache.DeletedFinalStateUnknown{Key: "cluster1/cluster-proxy", Obj: want})
+	if !ok || got != want {
+		t.Fatal("valid tombstone was not decoded")
+	}
+}
+
+func newManagedClusterAddon(namespace, name string) *addonv1beta1.ManagedClusterAddOn {
+	return &addonv1beta1.ManagedClusterAddOn{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func mustRequest(t *testing.T, url string) *http.Request {
+	t.Helper()
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return request
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,8 +24,6 @@ import (
 
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
-	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
-	addonlisterv1beta1 "open-cluster-management.io/api/client/addon/listers/addon/v1beta1"
 	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
 
 	"open-cluster-management.io/cluster-proxy/pkg/constant"
@@ -54,10 +51,6 @@ func NewUserServerCommand() *cobra.Command {
 	return cmd
 }
 
-var (
-	serviceProxyRootCA *x509.CertPool
-)
-
 type userServer struct {
 	getTunnel       func(context.Context) (konnectivity.Tunnel, error)
 	proxyServerHost string
@@ -72,8 +65,6 @@ type userServer struct {
 	agentInstallNamespace  string
 	drain                  utils.DrainConfig
 
-	addonLister addonlisterv1beta1.ManagedClusterAddOnLister
-
 	// exposedServicesConfigMap is the name of the ConfigMap (in the pod's own
 	// namespace) that lists permitted service proxy targets. Defaults to the
 	// well-known constant ExposedServicesConfigMapName.
@@ -87,12 +78,8 @@ type userServer struct {
 	idleConnTimeout     time.Duration
 	enableHTTP2         bool
 
-	// transports caches one http.Transport per managed cluster name.
-	// Each transport maintains a connection pool to the cluster's service-proxy,
-	// allowing tunnel reuse across sequential HTTP requests and eliminating the
-	// tunnel-per-request churn that saturates the ANP proxy-server under load.
-	// Key: cluster name (string), Value: *http.Transport
-	transports sync.Map
+	serviceProxyRootCA *x509.CertPool
+	transportPool      *clusterTransportPool
 }
 
 func (k *userServer) AddFlags(cmd *cobra.Command) {
@@ -147,22 +134,29 @@ func (k *userServer) Validate() error {
 }
 
 func newUserServer() *userServer {
-	return &userServer{
+	server := &userServer{
 		maxIdleConnsPerHost: 10,
 		maxConnsPerHost:     10,
 		idleConnTimeout:     90 * time.Second,
 		enableHTTP2:         true,
 	}
+	server.transportPool = newClusterTransportPool(server.newCachedTransport)
+	return server
 }
 
-func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, podNamespace string) error {
+func (k *userServer) init(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	addonClient addonclient.Interface,
+	podNamespace string,
+) error {
 	proxyTLSCfg, err := util.GetClientTLSConfig(k.proxyCACertPath, k.proxyCertPath, k.proxyKeyPath, k.proxyServerHost, nil)
 	if err != nil {
 		return err
 	}
 
 	// prepare ca for service proxy server
-	serviceProxyRootCA, err = certutil.NewPool(k.serviceProxyCACertPath)
+	k.serviceProxyRootCA, err = certutil.NewPool(k.serviceProxyCACertPath)
 	if err != nil {
 		return fmt.Errorf("failed to load service proxy ca cert: %w", err)
 	}
@@ -184,17 +178,9 @@ func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, 
 		return tunnel, nil
 	}
 
-	kubeConfig, err := ctrl.GetConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get Kubernetes config for add-on informer: %w", err)
+	if err := startManagedClusterAddonWatcher(ctx, addonClient, k.transportPool); err != nil {
+		return fmt.Errorf("failed to start managed cluster add-on watcher: %w", err)
 	}
-	addonClient, err := addonclient.NewForConfig(kubeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create add-on client: %w", err)
-	}
-	addonInformerFactory := addoninformers.NewSharedInformerFactory(addonClient, 30*time.Minute)
-	k.addonLister = addonInformerFactory.Addon().V1beta1().ManagedClusterAddOns().Lister()
-	addonInformerFactory.Start(ctx.Done())
 
 	// Start the service allowlist watcher. The watcher enforces default-deny:
 	// only services listed in the ConfigMap are reachable via the service proxy
@@ -212,47 +198,17 @@ func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, 
 	return nil
 }
 
-// getOrCreateTransport returns the cached *http.Transport for clusterName,
-// creating and storing one if none exists yet.
-//
-// A single transport is shared across all requests to the same cluster.
-// At high request rates, multiple connections may exist simultaneously, but
-// each is reused by subsequent requests rather than torn down after a single use.
-//
-// Without this caching, every HTTP request creates a new gRPC tunnel (full
-// TCP+TLS+HTTP/2 negotiation) regardless of whether an existing tunnel is idle.
-// Under load this saturates the ANP proxy-server with concurrent short-lived
-// Proxy() handlers, causing lock contention on shared state and channel
-// backpressure errors.
-func (k *userServer) getOrCreateTransport(clusterName string) *http.Transport {
-	if t, ok := k.transports.Load(clusterName); ok {
-		return t.(*http.Transport)
-	}
-
-	transport := &http.Transport{
+func (k *userServer) newCachedTransport(clusterName string) *http.Transport {
+	return &http.Transport{
 		MaxConnsPerHost:     k.maxConnsPerHost,
-		MaxIdleConns:        k.maxIdleConnsPerHost, // same as MaxIdleConnsPerHost since this transport serves a single host (one managed cluster)
+		MaxIdleConns:        k.maxIdleConnsPerHost,
 		MaxIdleConnsPerHost: k.maxIdleConnsPerHost,
 		IdleConnTimeout:     k.idleConnTimeout,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig: &tls.Config{
-			RootCAs:    serviceProxyRootCA,
+			RootCAs:    k.serviceProxyRootCA,
 			MinVersion: tls.VersionTLS12,
 		},
-		// Enable HTTP/2 on the cached transport. HTTP/2 multiplexes concurrent
-		// requests over a single connection via streams, so all concurrent REST
-		// API calls to the same cluster share one tunnel (one Proxy() handler on
-		// the proxy-server) instead of each needing their own. The service-proxy
-		// accepts HTTP/2 by default -- Go's http.Server enables it automatically
-		// when serving TLS with ListenAndServeTLS.
-		//
-		// SPDY upgrade requests (kubectl exec, VM console sessions) bypass this
-		// cached transport and use a dedicated HTTP/1.1 transport, so SPDY
-		// compatibility is not affected by enabling HTTP/2 here.
-		//
-		// If HTTP/2 negotiation fails (e.g. TLS profile incompatibility), the
-		// transport falls back to HTTP/1.1 automatically, in which case
-		// MaxConnsPerHost limits concurrent tunnels as a safety net.
 		ForceAttemptHTTP2:     k.enableHTTP2,
 		ExpectContinueTimeout: 1 * time.Second,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -264,12 +220,23 @@ func (k *userServer) getOrCreateTransport(clusterName string) *http.Transport {
 			return tunnel.DialContext(ctx, network, addr)
 		},
 	}
+}
 
-	// LoadOrStore handles the race where two goroutines concurrently create
-	// a transport for the same cluster -- the loser's transport is discarded
-	// (it has no active connections so there is no resource leak).
-	actual, _ := k.transports.LoadOrStore(clusterName, transport)
-	return actual.(*http.Transport)
+func (k *userServer) newUpgradeTransport(tunnel konnectivity.Tunnel) *http.Transport {
+	return &http.Transport{
+		IdleConnTimeout:       k.idleConnTimeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			RootCAs:    k.serviceProxyRootCA,
+			MinVersion: tls.VersionTLS12,
+		},
+		ForceAttemptHTTP2: false,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			klog.V(4).Infof("proxy dial to %s (upgrade request)", addr)
+			return tunnel.DialContext(ctx, network, addr)
+		},
+	}
 }
 
 func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
@@ -284,20 +251,13 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 
 	var tsc utils.TargetServiceConfig
 	var err error
+	proxyType := utils.GetProxyType(req.RequestURI)
 
-	switch utils.GetProxyType(req.RequestURI) {
+	switch proxyType {
 	case utils.ProxyTypeService:
 		tsc, err = utils.GetTargetServiceConfig(req.RequestURI)
 		if err != nil {
 			http.Error(wr, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if !k.serviceAllowlist.IsAllowed(tsc) {
-			klog.V(4).Infof("service proxy request denied: %s/%s is not in the exposed services allowlist",
-				tsc.Namespace, tsc.Service)
-			http.Error(wr,
-				fmt.Sprintf("service %s/%s is not in the exposed services allowlist", tsc.Namespace, tsc.Service),
-				http.StatusForbidden)
 			return
 		}
 	case utils.ProxyTypeKubeAPIServer:
@@ -308,22 +268,26 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	if !k.transportPool.isAllowed(tsc.Cluster) {
+		writeClusterNotFound(wr, tsc.Cluster)
+		return
+	}
+
+	if proxyType == utils.ProxyTypeService && !k.serviceAllowlist.IsAllowed(tsc) {
+		klog.V(4).Infof("service proxy request denied: %s/%s is not in the exposed services allowlist",
+			tsc.Namespace, tsc.Service)
+		http.Error(wr,
+			fmt.Sprintf("service %s/%s is not in the exposed services allowlist", tsc.Namespace, tsc.Service),
+			http.StatusForbidden)
+		return
+	}
+
 	targetURL, err := url.Parse(serviceProxyURL(tsc.Cluster))
 	if err != nil {
 		http.Error(wr, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// Upgrade requests (SPDY/WebSocket, e.g. kubectl exec, terminal sessions) are
-	// long-lived and need a dedicated tunnel for their duration. They bypass the
-	// shared transport cache and get a single-use HTTP/1.1 tunnel.
-	//
-	// REST API requests use the cached transport. Go's http.Transport retains
-	// the net.Conn (the konnectivity tunnel) in its idle pool after each request
-	// completes, so DialContext -- which creates a new gRPC tunnel -- is only
-	// called on a pool miss. Sequential requests to the same cluster reuse the
-	// idle connection and the existing Proxy() stream on the proxy-server,
-	// avoiding the per-request tunnel churn that causes proxy-server saturation.
 	var transport http.RoundTripper
 	if httpstream.IsUpgradeRequest(req) {
 		klog.V(4).Infof("upgrade request for cluster %s, using dedicated tunnel", tsc.Cluster)
@@ -332,30 +296,21 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 			http.Error(wr, err.Error(), http.StatusBadRequest)
 			return
 		}
-		transport = &http.Transport{
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig: &tls.Config{
-				RootCAs:    serviceProxyRootCA,
-				MinVersion: tls.VersionTLS12,
-			},
-			// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
-			// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
-			ForceAttemptHTTP2: false,
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				klog.V(4).Infof("proxy dial to %s (upgrade request)", addr)
-				return tunnel.DialContext(ctx, network, addr)
-			},
-		}
+		upgradeTransport := k.newUpgradeTransport(tunnel)
+		defer upgradeTransport.CloseIdleConnections()
+		transport = upgradeTransport
 	} else {
-		transport = k.getOrCreateTransport(tsc.Cluster)
+		var allowed bool
+		// Recheck membership in case the add-on was deleted after the policy checks above.
+		transport, allowed = k.transportPool.getOrCreate(tsc.Cluster)
+		if !allowed {
+			writeClusterNotFound(wr, tsc.Cluster)
+			return
+		}
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 	proxy.Transport = transport
-	proxy.FlushInterval = -1
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, r *http.Request, e error) {
 		http.Error(rw, fmt.Sprintf("proxy to anp-proxy-server failed because %v", e), http.StatusBadGateway)
@@ -365,6 +320,11 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	klog.V(4).Infof("request scheme:%s; rawQuery:%s; path:%s", req.URL.Scheme, req.URL.RawQuery, req.URL.Path)
 
 	proxy.ServeHTTP(wr, utils.UpdateRequest(tsc, req))
+}
+
+func writeClusterNotFound(wr http.ResponseWriter, clusterName string) {
+	message := fmt.Sprintf("cluster %q does not have the %s add-on installed", clusterName, constant.AddonName)
+	http.Error(wr, message, http.StatusNotFound)
 }
 
 func (k *userServer) Run(ctx context.Context) error {
@@ -394,10 +354,15 @@ func (k *userServer) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
+	addonClient, err := addonclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create add-on client: %w", err)
+	}
 
-	if err = k.init(runCtx, kubeClient, podNamespace); err != nil {
+	if err = k.init(runCtx, kubeClient, addonClient, podNamespace); err != nil {
 		return err
 	}
+	defer k.transportPool.closeAll()
 
 	sdkTLSConfig, err := sdktls.StartTLSConfigMapWatcher(runCtx, kubeClient, podNamespace, func() {
 		klog.Info("TLS ConfigMap changed, shutting down gracefully for restart")

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -57,7 +58,6 @@ var (
 )
 
 type userServer struct {
-	// TODO: make it a controller and reuse tunnel for each cluster to improve performance.
 	getTunnel       func(context.Context) (konnectivity.Tunnel, error)
 	proxyServerHost string
 	proxyServerPort int
@@ -80,6 +80,17 @@ type userServer struct {
 	// serviceAllowlist is populated at startup from the ConfigMap and kept
 	// up to date by an informer.
 	serviceAllowlist *ServiceAllowlist
+
+	maxConnsPerHost     int
+	maxIdleConnsPerHost int
+	idleConnTimeout     time.Duration
+
+	// transports caches one http.Transport per managed cluster name.
+	// Each transport maintains a connection pool to the cluster's service-proxy,
+	// allowing tunnel reuse across sequential HTTP requests and eliminating the
+	// tunnel-per-request churn that saturates the ANP proxy-server under load.
+	// Key: cluster name (string), Value: *http.Transport
+	transports sync.Map
 }
 
 func (k *userServer) AddFlags(cmd *cobra.Command) {
@@ -130,7 +141,11 @@ func (k *userServer) Validate() error {
 }
 
 func newUserServer() *userServer {
-	return &userServer{}
+	return &userServer{
+		maxIdleConnsPerHost: 10,
+		maxConnsPerHost:     10,
+		idleConnTimeout:     90 * time.Second,
+	}
 }
 
 func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, podNamespace string) error {
@@ -184,7 +199,58 @@ func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, 
 	klog.Infof("service allowlist active: %d entries loaded from ConfigMap %s/%s",
 		k.serviceAllowlist.Len(), podNamespace, k.exposedServicesConfigMap)
 
+	klog.Infof("transport pool config: maxConnsPerHost=%d maxIdleConnsPerHost=%d idleConnTimeout=%v",
+		k.maxConnsPerHost, k.maxIdleConnsPerHost, k.idleConnTimeout)
+
 	return nil
+}
+
+// getOrCreateTransport returns the cached *http.Transport for clusterName,
+// creating and storing one if none exists yet.
+//
+// A single transport is shared across all requests to the same cluster.
+// At high request rates, multiple connections may exist simultaneously, but
+// each is reused by subsequent requests rather than torn down after a single use.
+//
+// Without this caching, every HTTP request creates a new gRPC tunnel (full
+// TCP+TLS+HTTP/2 negotiation) regardless of whether an existing tunnel is idle.
+// Under load this saturates the ANP proxy-server with concurrent short-lived
+// Proxy() handlers, causing lock contention on shared state and channel
+// backpressure errors.
+func (k *userServer) getOrCreateTransport(clusterName string) *http.Transport {
+	if t, ok := k.transports.Load(clusterName); ok {
+		return t.(*http.Transport)
+	}
+
+	transport := &http.Transport{
+		MaxConnsPerHost:     k.maxConnsPerHost,
+		MaxIdleConns:        k.maxIdleConnsPerHost, // same as MaxIdleConnsPerHost since this transport serves a single host (one managed cluster)
+		MaxIdleConnsPerHost: k.maxIdleConnsPerHost,
+		IdleConnTimeout:     k.idleConnTimeout,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			RootCAs:    serviceProxyRootCA,
+			MinVersion: tls.VersionTLS12,
+		},
+		// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
+		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
+		ForceAttemptHTTP2:     false,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			klog.V(4).Infof("creating tunnel for cluster %s (transport pool miss)", clusterName)
+			tunnel, err := k.getTunnel(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return tunnel.DialContext(ctx, network, addr)
+		},
+	}
+
+	// LoadOrStore handles the race where two goroutines concurrently create
+	// a transport for the same cluster -- the loser's transport is discarded
+	// (it has no active connections so there is no resource leak).
+	actual, _ := k.transports.LoadOrStore(clusterName, transport)
+	return actual.(*http.Transport)
 }
 
 func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
@@ -229,32 +295,8 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	tunnel, err := k.getTunnel(req.Context())
-	if err != nil {
-		http.Error(wr, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-	proxy.Transport = &http.Transport{
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		// Not using our global TLSConfig for outbound will rely on server settings
-		TLSClientConfig: &tls.Config{
-			RootCAs:    serviceProxyRootCA,
-			MinVersion: tls.VersionTLS12,
-		},
-		// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
-		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
-		ForceAttemptHTTP2: false,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			klog.V(4).Infof("proxy dial to %s", addr)
-			// TODO: may find a way to cache the proxyConn.
-			return tunnel.DialContext(ctx, network, addr)
-		},
-	}
+	proxy.Transport = k.getOrCreateTransport(tsc.Cluster)
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, r *http.Request, e error) {
 		http.Error(rw, fmt.Sprintf("proxy to anp-proxy-server failed because %v", e), http.StatusBadGateway)

--- a/pkg/userserver/user_server.go
+++ b/pkg/userserver/user_server.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
+	"k8s.io/streaming/pkg/httpstream"
 
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
@@ -84,6 +85,7 @@ type userServer struct {
 	maxConnsPerHost     int
 	maxIdleConnsPerHost int
 	idleConnTimeout     time.Duration
+	enableHTTP2         bool
 
 	// transports caches one http.Transport per managed cluster name.
 	// Each transport maintains a connection pool to the cluster's service-proxy,
@@ -114,6 +116,10 @@ func (k *userServer) AddFlags(cmd *cobra.Command) {
 
 	flags.StringVar(&k.exposedServicesConfigMap, "exposed-services-configmap", constant.ExposedServicesConfigMapName,
 		"Name of the ConfigMap (in the pod's namespace) that lists which services are reachable via the service proxy path")
+
+	flags.BoolVar(&k.enableHTTP2, "enable-http2", true,
+		"Enable HTTP/2 on the cached transport to multiplex concurrent requests over a single tunnel. "+
+			"Disable to fall back to HTTP/1.1 if HTTP/2 causes compatibility issues.")
 }
 
 func (k *userServer) Validate() error {
@@ -145,6 +151,7 @@ func newUserServer() *userServer {
 		maxIdleConnsPerHost: 10,
 		maxConnsPerHost:     10,
 		idleConnTimeout:     90 * time.Second,
+		enableHTTP2:         true,
 	}
 }
 
@@ -199,8 +206,8 @@ func (k *userServer) init(ctx context.Context, kubeClient kubernetes.Interface, 
 	klog.Infof("service allowlist active: %d entries loaded from ConfigMap %s/%s",
 		k.serviceAllowlist.Len(), podNamespace, k.exposedServicesConfigMap)
 
-	klog.Infof("transport pool config: maxConnsPerHost=%d maxIdleConnsPerHost=%d idleConnTimeout=%v",
-		k.maxConnsPerHost, k.maxIdleConnsPerHost, k.idleConnTimeout)
+	klog.Infof("transport pool config: maxConnsPerHost=%d maxIdleConnsPerHost=%d idleConnTimeout=%v http2=%v",
+		k.maxConnsPerHost, k.maxIdleConnsPerHost, k.idleConnTimeout, k.enableHTTP2)
 
 	return nil
 }
@@ -232,9 +239,21 @@ func (k *userServer) getOrCreateTransport(clusterName string) *http.Transport {
 			RootCAs:    serviceProxyRootCA,
 			MinVersion: tls.VersionTLS12,
 		},
-		// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
-		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
-		ForceAttemptHTTP2:     false,
+		// Enable HTTP/2 on the cached transport. HTTP/2 multiplexes concurrent
+		// requests over a single connection via streams, so all concurrent REST
+		// API calls to the same cluster share one tunnel (one Proxy() handler on
+		// the proxy-server) instead of each needing their own. The service-proxy
+		// accepts HTTP/2 by default -- Go's http.Server enables it automatically
+		// when serving TLS with ListenAndServeTLS.
+		//
+		// SPDY upgrade requests (kubectl exec, VM console sessions) bypass this
+		// cached transport and use a dedicated HTTP/1.1 transport, so SPDY
+		// compatibility is not affected by enabling HTTP/2 here.
+		//
+		// If HTTP/2 negotiation fails (e.g. TLS profile incompatibility), the
+		// transport falls back to HTTP/1.1 automatically, in which case
+		// MaxConnsPerHost limits concurrent tunnels as a safety net.
+		ForceAttemptHTTP2:     k.enableHTTP2,
 		ExpectContinueTimeout: 1 * time.Second,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			klog.V(4).Infof("creating tunnel for cluster %s (transport pool miss)", clusterName)
@@ -295,8 +314,48 @@ func (k *userServer) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Upgrade requests (SPDY/WebSocket, e.g. kubectl exec, terminal sessions) are
+	// long-lived and need a dedicated tunnel for their duration. They bypass the
+	// shared transport cache and get a single-use HTTP/1.1 tunnel.
+	//
+	// REST API requests use the cached transport. Go's http.Transport retains
+	// the net.Conn (the konnectivity tunnel) in its idle pool after each request
+	// completes, so DialContext -- which creates a new gRPC tunnel -- is only
+	// called on a pool miss. Sequential requests to the same cluster reuse the
+	// idle connection and the existing Proxy() stream on the proxy-server,
+	// avoiding the per-request tunnel churn that causes proxy-server saturation.
+	var transport http.RoundTripper
+	if httpstream.IsUpgradeRequest(req) {
+		klog.V(4).Infof("upgrade request for cluster %s, using dedicated tunnel", tsc.Cluster)
+		tunnel, err := k.getTunnel(req.Context())
+		if err != nil {
+			http.Error(wr, err.Error(), http.StatusBadRequest)
+			return
+		}
+		transport = &http.Transport{
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			TLSClientConfig: &tls.Config{
+				RootCAs:    serviceProxyRootCA,
+				MinVersion: tls.VersionTLS12,
+			},
+			// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
+			// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
+			ForceAttemptHTTP2: false,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				klog.V(4).Infof("proxy dial to %s (upgrade request)", addr)
+				return tunnel.DialContext(ctx, network, addr)
+			},
+		}
+	} else {
+		transport = k.getOrCreateTransport(tsc.Cluster)
+	}
+
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-	proxy.Transport = k.getOrCreateTransport(tsc.Cluster)
+	proxy.Transport = transport
+	proxy.FlushInterval = -1
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, r *http.Request, e error) {
 		http.Error(rw, fmt.Sprintf("proxy to anp-proxy-server failed because %v", e), http.StatusBadGateway)

--- a/pkg/userserver/user_server_test.go
+++ b/pkg/userserver/user_server_test.go
@@ -1,0 +1,222 @@
+package userserver
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+)
+
+// fakeConn is a minimal net.Conn that satisfies the interface for tests.
+type fakeConn struct{}
+
+func (f *fakeConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (f *fakeConn) Write(b []byte) (int, error)        { return len(b), nil }
+func (f *fakeConn) Close() error                       { return nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (f *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+var _ net.Conn = (*fakeConn)(nil)
+
+// fakeTunnel implements konnectivity.Tunnel and counts DialContext calls.
+type fakeTunnel struct {
+	dialCount int64
+	done      chan struct{}
+}
+
+func newFakeTunnel() *fakeTunnel {
+	t := &fakeTunnel{done: make(chan struct{})}
+	close(t.done)
+	return t
+}
+
+func (f *fakeTunnel) DialContext(_ context.Context, _, _ string) (net.Conn, error) {
+	atomic.AddInt64(&f.dialCount, 1)
+	return &fakeConn{}, nil
+}
+
+func (f *fakeTunnel) Done() <-chan struct{} { return f.done }
+
+var _ konnectivity.Tunnel = (*fakeTunnel)(nil)
+
+// newTestUserServer creates a userServer via newUserServer() (so defaults are
+// properly initialised) with a custom getTunnel for testing.
+func newTestUserServer(getTunnel func(context.Context) (konnectivity.Tunnel, error)) *userServer {
+	s := newUserServer()
+	s.getTunnel = getTunnel
+	return s
+}
+
+// --- getOrCreateTransport tests ---
+
+func TestGetOrCreateTransport_ReturnsSameTransportForSameCluster(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+
+	t1 := s.getOrCreateTransport("cluster1")
+	t2 := s.getOrCreateTransport("cluster1")
+
+	if t1 != t2 {
+		t.Fatal("expected same *http.Transport for same cluster, got different pointers")
+	}
+}
+
+func TestGetOrCreateTransport_ReturnsDifferentTransportForDifferentClusters(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+
+	ta := s.getOrCreateTransport("cluster-a")
+	tb := s.getOrCreateTransport("cluster-b")
+
+	if ta == tb {
+		t.Fatal("expected different *http.Transport for different clusters, got same pointer")
+	}
+}
+
+func TestGetOrCreateTransport_Settings(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+
+	transport := s.getOrCreateTransport("cluster1")
+
+	// MaxConnsPerHost should equal the resolved maxConnsPerHost on the struct.
+	if transport.MaxConnsPerHost != s.maxConnsPerHost {
+		t.Errorf("MaxConnsPerHost: got %d, want %d",
+			transport.MaxConnsPerHost, s.maxConnsPerHost)
+	}
+	// MaxIdleConns should equal MaxIdleConnsPerHost (single-host transport).
+	if transport.MaxIdleConns != s.maxIdleConnsPerHost {
+		t.Errorf("MaxIdleConns: got %d, want %d (should match MaxIdleConnsPerHost)",
+			transport.MaxIdleConns, s.maxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConnsPerHost != s.maxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost: got %d, want %d",
+			transport.MaxIdleConnsPerHost, s.maxIdleConnsPerHost)
+	}
+	if transport.IdleConnTimeout != s.idleConnTimeout {
+		t.Errorf("IdleConnTimeout: got %v, want %v",
+			transport.IdleConnTimeout, s.idleConnTimeout)
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig must not be nil")
+	}
+
+	// Verify hardcoded defaults.
+	if s.maxConnsPerHost != 10 {
+		t.Errorf("default maxConnsPerHost: got %d, want 10", s.maxConnsPerHost)
+	}
+	if s.maxIdleConnsPerHost != 10 {
+		t.Errorf("default maxIdleConnsPerHost: got %d, want 10", s.maxIdleConnsPerHost)
+	}
+	if s.idleConnTimeout != 90*time.Second {
+		t.Errorf("default idleConnTimeout: got %v, want 90s", s.idleConnTimeout)
+	}
+}
+
+func TestGetOrCreateTransport_ConcurrentAccessReturnsSameTransport(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+
+	const goroutines = 50
+	results := make([]*http.Transport, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			results[i] = s.getOrCreateTransport("cluster1")
+		}()
+	}
+	wg.Wait()
+
+	first := results[0]
+	for i, tr := range results {
+		if tr != first {
+			t.Errorf("goroutine %d got a different transport pointer", i)
+		}
+	}
+}
+
+func TestGetOrCreateTransport_DialContextCreatesNewTunnelOnPoolMiss(t *testing.T) {
+	var tunnelCount int64
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	})
+
+	transport := s.getOrCreateTransport("cluster1")
+
+	// First pool miss: expect one tunnel.
+	conn, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
+	if err != nil {
+		t.Fatalf("first DialContext: %v", err)
+	}
+	conn.Close()
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 1 {
+		t.Errorf("after first pool miss: got %d tunnels, want 1", got)
+	}
+
+	// Second pool miss: expect a second tunnel (each tunnel is single-use).
+	conn2, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
+	if err != nil {
+		t.Fatalf("second DialContext: %v", err)
+	}
+	conn2.Close()
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 2 {
+		t.Errorf("after second pool miss: got %d tunnels, want 2", got)
+	}
+}
+
+func TestGetOrCreateTransport_TunnelNotCreatedOnCacheLookup(t *testing.T) {
+	// Verifies that merely looking up the cached transport does not call
+	// getTunnel -- tunnels are created lazily on DialContext (pool miss).
+	var tunnelCount int64
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	})
+
+	// Two cache lookups -- no DialContext calls yet.
+	_ = s.getOrCreateTransport("cluster1")
+	_ = s.getOrCreateTransport("cluster1")
+
+	if got := atomic.LoadInt64(&tunnelCount); got != 0 {
+		t.Errorf("getTunnel must not be called during cache lookup, got %d calls", got)
+	}
+}
+
+func TestServeHTTP_DifferentClustersGetDifferentTransports(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+
+	ta := s.getOrCreateTransport("cluster-a")
+	tb := s.getOrCreateTransport("cluster-b")
+
+	if ta == tb {
+		t.Error("different clusters must have different cached transports")
+	}
+	if s.getOrCreateTransport("cluster-a") != ta {
+		t.Error("second lookup for cluster-a must return the same transport")
+	}
+	if s.getOrCreateTransport("cluster-b") != tb {
+		t.Error("second lookup for cluster-b must return the same transport")
+	}
+}

--- a/pkg/userserver/user_server_test.go
+++ b/pkg/userserver/user_server_test.go
@@ -2,9 +2,12 @@ package userserver
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -47,6 +50,36 @@ func (f *fakeTunnel) DialContext(_ context.Context, _, _ string) (net.Conn, erro
 func (f *fakeTunnel) Done() <-chan struct{} { return f.done }
 
 var _ konnectivity.Tunnel = (*fakeTunnel)(nil)
+
+// dialingFakeTunnel dials a real TCP address, for tests that need ServeHTTP to
+// complete an actual HTTP round-trip.
+type dialingFakeTunnel struct {
+	addr string
+	done chan struct{}
+}
+
+func newDialingFakeTunnel(addr string) *dialingFakeTunnel {
+	t := &dialingFakeTunnel{addr: addr, done: make(chan struct{})}
+	close(t.done)
+	return t
+}
+
+func (d *dialingFakeTunnel) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, d.addr)
+}
+
+func (d *dialingFakeTunnel) Done() <-chan struct{} { return d.done }
+
+var _ konnectivity.Tunnel = (*dialingFakeTunnel)(nil)
+
+// setupServiceProxyRootCA overrides the package-level serviceProxyRootCA for
+// the duration of a test and restores it on cleanup.
+func setupServiceProxyRootCA(t *testing.T, pool *x509.CertPool) {
+	t.Helper()
+	old := serviceProxyRootCA
+	serviceProxyRootCA = pool
+	t.Cleanup(func() { serviceProxyRootCA = old })
+}
 
 // newTestUserServer creates a userServer via newUserServer() (so defaults are
 // properly initialised) with a custom getTunnel for testing.
@@ -112,6 +145,13 @@ func TestGetOrCreateTransport_Settings(t *testing.T) {
 	if transport.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig must not be nil")
 	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("TLS MinVersion: got %d, want %d (TLS 1.2)",
+			transport.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be true on cached transport to enable HTTP/2 multiplexing")
+	}
 
 	// Verify hardcoded defaults.
 	if s.maxConnsPerHost != 10 {
@@ -122,6 +162,9 @@ func TestGetOrCreateTransport_Settings(t *testing.T) {
 	}
 	if s.idleConnTimeout != 90*time.Second {
 		t.Errorf("default idleConnTimeout: got %v, want 90s", s.idleConnTimeout)
+	}
+	if !s.enableHTTP2 {
+		t.Error("enableHTTP2 must default to true")
 	}
 }
 
@@ -218,5 +261,80 @@ func TestServeHTTP_DifferentClustersGetDifferentTransports(t *testing.T) {
 	}
 	if s.getOrCreateTransport("cluster-b") != tb {
 		t.Error("second lookup for cluster-b must return the same transport")
+	}
+}
+
+// --- ServeHTTP upgrade-detection tests ---
+
+func TestServeHTTP_NonUpgradeUsesTransportCache(t *testing.T) {
+	// Verifies that non-upgrade requests use the cached transport (getTunnel is
+	// not called just from cache lookup -- only on a DialContext pool miss).
+	var tunnelCount int64
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newFakeTunnel(), nil
+	})
+
+	// Seeding the cache must not trigger getTunnel.
+	preexisting := s.getOrCreateTransport("mycluster")
+	if atomic.LoadInt64(&tunnelCount) != 0 {
+		t.Fatal("getTunnel must not be called on cache seed")
+	}
+
+	// A second lookup must return the same transport.
+	if s.getOrCreateTransport("mycluster") != preexisting {
+		t.Error("second cache lookup returned a different transport")
+	}
+}
+
+func TestServeHTTP_UpgradeRequestBypassesTransportCache(t *testing.T) {
+	// Start a TLS backend that just returns 200.
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	rootCAs := backend.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs
+	setupServiceProxyRootCA(t, rootCAs)
+
+	var tunnelCount int64
+	s := newTestUserServer(func(ctx context.Context) (konnectivity.Tunnel, error) {
+		atomic.AddInt64(&tunnelCount, 1)
+		return newDialingFakeTunnel(backend.Listener.Addr().String()), nil
+	})
+
+	// Seed the cache for this cluster.
+	preexisting := s.getOrCreateTransport("mycluster")
+
+	// Send an upgrade request.
+	req := httptest.NewRequest(http.MethodGet,
+		"/mycluster/api/v1/namespaces/default/pods/pod/exec", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "SPDY/3.1")
+	rr := httptest.NewRecorder()
+
+	s.ServeHTTP(rr, req)
+
+	// getTunnel must have been called for the upgrade request (bypass path).
+	if got := atomic.LoadInt64(&tunnelCount); got == 0 {
+		t.Error("getTunnel must be called for upgrade requests")
+	}
+
+	// The cached transport must be unchanged.
+	if s.getOrCreateTransport("mycluster") != preexisting {
+		t.Error("upgrade request must not replace the cached transport")
+	}
+}
+
+func TestGetOrCreateTransport_HTTP2DisabledViaFlag(t *testing.T) {
+	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
+		return newFakeTunnel(), nil
+	})
+	s.enableHTTP2 = false
+
+	transport := s.getOrCreateTransport("cluster1")
+
+	if transport.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be false when --enable-http2=false")
 	}
 }

--- a/pkg/userserver/user_server_test.go
+++ b/pkg/userserver/user_server_test.go
@@ -1,340 +1,475 @@
 package userserver
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	certutil "k8s.io/client-go/util/cert"
+
 	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 )
 
-// fakeConn is a minimal net.Conn that satisfies the interface for tests.
-type fakeConn struct{}
+const testClusterName = "cluster1"
 
-func (f *fakeConn) Read(b []byte) (int, error)         { return 0, io.EOF }
-func (f *fakeConn) Write(b []byte) (int, error)        { return len(b), nil }
-func (f *fakeConn) Close() error                       { return nil }
-func (f *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
-func (f *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
-func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
-func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
-func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
-
-var _ net.Conn = (*fakeConn)(nil)
-
-// fakeTunnel implements konnectivity.Tunnel and counts DialContext calls.
-type fakeTunnel struct {
-	dialCount int64
-	done      chan struct{}
+type dialingTunnel struct {
+	address string
+	done    chan struct{}
 }
 
-func newFakeTunnel() *fakeTunnel {
-	t := &fakeTunnel{done: make(chan struct{})}
-	close(t.done)
-	return t
+func newDialingTunnel(address string) *dialingTunnel {
+	done := make(chan struct{})
+	close(done)
+	return &dialingTunnel{address: address, done: done}
 }
 
-func (f *fakeTunnel) DialContext(_ context.Context, _, _ string) (net.Conn, error) {
-	atomic.AddInt64(&f.dialCount, 1)
-	return &fakeConn{}, nil
+func (t *dialingTunnel) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, t.address)
 }
 
-func (f *fakeTunnel) Done() <-chan struct{} { return f.done }
-
-var _ konnectivity.Tunnel = (*fakeTunnel)(nil)
-
-// dialingFakeTunnel dials a real TCP address, for tests that need ServeHTTP to
-// complete an actual HTTP round-trip.
-type dialingFakeTunnel struct {
-	addr string
-	done chan struct{}
+func (t *dialingTunnel) Done() <-chan struct{} {
+	return t.done
 }
 
-func newDialingFakeTunnel(addr string) *dialingFakeTunnel {
-	t := &dialingFakeTunnel{addr: addr, done: make(chan struct{})}
-	close(t.done)
-	return t
-}
+var _ konnectivity.Tunnel = (*dialingTunnel)(nil)
 
-func (d *dialingFakeTunnel) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
-	return (&net.Dialer{}).DialContext(ctx, network, d.addr)
-}
-
-func (d *dialingFakeTunnel) Done() <-chan struct{} { return d.done }
-
-var _ konnectivity.Tunnel = (*dialingFakeTunnel)(nil)
-
-// setupServiceProxyRootCA overrides the package-level serviceProxyRootCA for
-// the duration of a test and restores it on cleanup.
-func setupServiceProxyRootCA(t *testing.T, pool *x509.CertPool) {
-	t.Helper()
-	old := serviceProxyRootCA
-	serviceProxyRootCA = pool
-	t.Cleanup(func() { serviceProxyRootCA = old })
-}
-
-// newTestUserServer creates a userServer via newUserServer() (so defaults are
-// properly initialised) with a custom getTunnel for testing.
-func newTestUserServer(getTunnel func(context.Context) (konnectivity.Tunnel, error)) *userServer {
-	s := newUserServer()
-	s.getTunnel = getTunnel
-	return s
-}
-
-// --- getOrCreateTransport tests ---
-
-func TestGetOrCreateTransport_ReturnsSameTransportForSameCluster(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
-	})
-
-	t1 := s.getOrCreateTransport("cluster1")
-	t2 := s.getOrCreateTransport("cluster1")
-
-	if t1 != t2 {
-		t.Fatal("expected same *http.Transport for same cluster, got different pointers")
+func TestCachedTransportSettings(t *testing.T) {
+	server := newUserServer()
+	server.transportPool.allow(testClusterName)
+	transport, ok := server.transportPool.getOrCreate(testClusterName)
+	if !ok {
+		t.Fatal("expected transport for allowed cluster")
 	}
-}
 
-func TestGetOrCreateTransport_ReturnsDifferentTransportForDifferentClusters(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
-	})
-
-	ta := s.getOrCreateTransport("cluster-a")
-	tb := s.getOrCreateTransport("cluster-b")
-
-	if ta == tb {
-		t.Fatal("expected different *http.Transport for different clusters, got same pointer")
+	if transport.MaxConnsPerHost != 10 {
+		t.Errorf("MaxConnsPerHost = %d, want 10", transport.MaxConnsPerHost)
 	}
-}
-
-func TestGetOrCreateTransport_Settings(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
-	})
-
-	transport := s.getOrCreateTransport("cluster1")
-
-	// MaxConnsPerHost should equal the resolved maxConnsPerHost on the struct.
-	if transport.MaxConnsPerHost != s.maxConnsPerHost {
-		t.Errorf("MaxConnsPerHost: got %d, want %d",
-			transport.MaxConnsPerHost, s.maxConnsPerHost)
+	if transport.MaxIdleConns != 10 {
+		t.Errorf("MaxIdleConns = %d, want 10", transport.MaxIdleConns)
 	}
-	// MaxIdleConns should equal MaxIdleConnsPerHost (single-host transport).
-	if transport.MaxIdleConns != s.maxIdleConnsPerHost {
-		t.Errorf("MaxIdleConns: got %d, want %d (should match MaxIdleConnsPerHost)",
-			transport.MaxIdleConns, s.maxIdleConnsPerHost)
+	if transport.MaxIdleConnsPerHost != 10 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 10", transport.MaxIdleConnsPerHost)
 	}
-	if transport.MaxIdleConnsPerHost != s.maxIdleConnsPerHost {
-		t.Errorf("MaxIdleConnsPerHost: got %d, want %d",
-			transport.MaxIdleConnsPerHost, s.maxIdleConnsPerHost)
+	if transport.IdleConnTimeout != 90*time.Second {
+		t.Errorf("IdleConnTimeout = %s, want 90s", transport.IdleConnTimeout)
 	}
-	if transport.IdleConnTimeout != s.idleConnTimeout {
-		t.Errorf("IdleConnTimeout: got %v, want %v",
-			transport.IdleConnTimeout, s.idleConnTimeout)
-	}
-	if transport.TLSClientConfig == nil {
-		t.Fatal("TLSClientConfig must not be nil")
-	}
-	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
-		t.Errorf("TLS MinVersion: got %d, want %d (TLS 1.2)",
-			transport.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatal("cached transport must require TLS 1.2 or newer")
 	}
 	if !transport.ForceAttemptHTTP2 {
-		t.Error("ForceAttemptHTTP2 must be true on cached transport to enable HTTP/2 multiplexing")
+		t.Fatal("HTTP/2 must be enabled by default")
 	}
 
-	// Verify hardcoded defaults.
-	if s.maxConnsPerHost != 10 {
-		t.Errorf("default maxConnsPerHost: got %d, want 10", s.maxConnsPerHost)
+	server.enableHTTP2 = false
+	disabled := server.newCachedTransport("cluster2")
+	if disabled.ForceAttemptHTTP2 {
+		t.Fatal("HTTP/2 must be disabled when --enable-http2=false")
 	}
-	if s.maxIdleConnsPerHost != 10 {
-		t.Errorf("default maxIdleConnsPerHost: got %d, want 10", s.maxIdleConnsPerHost)
-	}
-	if s.idleConnTimeout != 90*time.Second {
-		t.Errorf("default idleConnTimeout: got %v, want 90s", s.idleConnTimeout)
-	}
-	if !s.enableHTTP2 {
-		t.Error("enableHTTP2 must default to true")
+	if server.newUpgradeTransport(newDialingTunnel("127.0.0.1:1")).ForceAttemptHTTP2 {
+		t.Fatal("upgrade transport must always use HTTP/1.1")
 	}
 }
 
-func TestGetOrCreateTransport_ConcurrentAccessReturnsSameTransport(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
-	})
+func TestServeHTTPRejectsUnroutableRequestsWithoutCreatingTransport(t *testing.T) {
+	tests := map[string]struct {
+		path           string
+		allowedCluster bool
+		allowedService bool
+		wantStatus     int
+	}{
+		"unknown cluster Kubernetes API": {
+			path:       kubeAPIPath("unknown"),
+			wantStatus: http.StatusNotFound,
+		},
+		"unknown cluster disallowed service": {
+			path:       serviceProxyPath("unknown"),
+			wantStatus: http.StatusNotFound,
+		},
+		"unknown cluster allowed service": {
+			path:           serviceProxyPath("unknown"),
+			allowedService: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		"known cluster disallowed service": {
+			path:           serviceProxyPath(testClusterName),
+			allowedCluster: true,
+			wantStatus:     http.StatusForbidden,
+		},
+	}
 
-	const goroutines = 50
-	results := make([]*http.Transport, goroutines)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var tunnelCount atomic.Int64
+			server := newTestUserServer(nil, func(context.Context) (konnectivity.Tunnel, error) {
+				tunnelCount.Add(1)
+				return nil, fmt.Errorf("unexpected tunnel")
+			})
+			if test.allowedCluster {
+				server.transportPool.allow(testClusterName)
+			}
+			if test.allowedService {
+				server.serviceAllowlist.update([]ExposedService{{
+					Namespace: "default",
+					Service:   "example",
+					Port:      "80",
+					Protocol:  "http",
+				}})
+			}
+
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, request)
+
+			if recorder.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%q", recorder.Code, test.wantStatus, recorder.Body.String())
+			}
+			if got := tunnelCount.Load(); got != 0 {
+				t.Fatalf("getTunnel called %d times, want 0", got)
+			}
+			server.transportPool.mu.RLock()
+			cachedTransports := len(server.transportPool.transports)
+			server.transportPool.mu.RUnlock()
+			if cachedTransports != 0 {
+				t.Fatalf("created %d cached transports, want 0", cachedTransports)
+			}
+		})
+	}
+}
+
+func TestServeHTTPReusesOneHTTP2Tunnel(t *testing.T) {
+	protocols := make(chan string, 2)
+	backend, roots := newTLSBackend(t, testClusterName, true, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		protocols <- request.Proto
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server, tunnelCount := newProxyToBackend(t, roots, backend.Listener.Addr().String(), true)
+	proxy := httptest.NewServer(server)
+	t.Cleanup(proxy.Close)
+
+	for range 2 {
+		response := getResponse(t, proxy.Client(), proxy.URL+kubeAPIPath(testClusterName))
+		if response != "ok" {
+			t.Fatalf("response body = %q, want %q", response, "ok")
+		}
+	}
+
+	for range 2 {
+		if protocol := <-protocols; protocol != "HTTP/2.0" {
+			t.Fatalf("backend protocol = %q, want HTTP/2.0", protocol)
+		}
+	}
+	if got := tunnelCount.Load(); got != 1 {
+		t.Fatalf("created %d tunnels for two sequential requests, want 1", got)
+	}
+}
+
+func TestServeHTTPMultiplexesConcurrentRequestsOverOneHTTP2Tunnel(t *testing.T) {
+	var active atomic.Int64
+	var maximum atomic.Int64
+	backend, roots := newTLSBackend(t, testClusterName, true, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			previous := maximum.Load()
+			if current <= previous || maximum.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server, tunnelCount := newProxyToBackend(t, roots, backend.Listener.Addr().String(), true)
+	proxy := httptest.NewServer(server)
+	t.Cleanup(proxy.Close)
+
+	getResponse(t, proxy.Client(), proxy.URL+kubeAPIPath(testClusterName))
+
+	const requests = 64
+	errors := make(chan error, requests)
 	var wg sync.WaitGroup
-	wg.Add(goroutines)
-
-	for i := 0; i < goroutines; i++ {
-		i := i
+	for range requests {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results[i] = s.getOrCreateTransport("cluster1")
+			response, err := proxy.Client().Get(proxy.URL + kubeAPIPath(testClusterName))
+			if err != nil {
+				errors <- err
+				return
+			}
+			defer response.Body.Close()
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				errors <- err
+				return
+			}
+			if response.StatusCode != http.StatusOK || string(body) != "ok" {
+				errors <- fmt.Errorf("status=%d body=%q", response.StatusCode, body)
+			}
 		}()
 	}
 	wg.Wait()
+	close(errors)
+	for err := range errors {
+		t.Errorf("concurrent request: %v", err)
+	}
+	if maximum.Load() < 2 {
+		t.Fatal("backend requests did not overlap, so multiplexing was not exercised")
+	}
+	if got := tunnelCount.Load(); got != 1 {
+		t.Fatalf("created %d tunnels after warmup and %d concurrent requests, want 1", got, requests)
+	}
+}
 
-	first := results[0]
-	for i, tr := range results {
-		if tr != first {
-			t.Errorf("goroutine %d got a different transport pointer", i)
+func TestServeHTTPReusesHTTP1TunnelWhenHTTP2Disabled(t *testing.T) {
+	protocols := make(chan string, 2)
+	backend, roots := newTLSBackend(t, testClusterName, true, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		protocols <- request.Proto
+		_, _ = io.WriteString(w, "ok")
+	}))
+	server, tunnelCount := newProxyToBackend(t, roots, backend.Listener.Addr().String(), false)
+	proxy := httptest.NewServer(server)
+	t.Cleanup(proxy.Close)
+
+	for range 2 {
+		getResponse(t, proxy.Client(), proxy.URL+kubeAPIPath(testClusterName))
+	}
+
+	for range 2 {
+		if protocol := <-protocols; protocol != "HTTP/1.1" {
+			t.Fatalf("backend protocol = %q, want HTTP/1.1", protocol)
 		}
 	}
-}
-
-func TestGetOrCreateTransport_DialContextCreatesNewTunnelOnPoolMiss(t *testing.T) {
-	var tunnelCount int64
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		atomic.AddInt64(&tunnelCount, 1)
-		return newFakeTunnel(), nil
-	})
-
-	transport := s.getOrCreateTransport("cluster1")
-
-	// First pool miss: expect one tunnel.
-	conn, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
-	if err != nil {
-		t.Fatalf("first DialContext: %v", err)
-	}
-	conn.Close()
-
-	if got := atomic.LoadInt64(&tunnelCount); got != 1 {
-		t.Errorf("after first pool miss: got %d tunnels, want 1", got)
-	}
-
-	// Second pool miss: expect a second tunnel (each tunnel is single-use).
-	conn2, err := transport.DialContext(context.Background(), "tcp", "cluster1.proxy:7443")
-	if err != nil {
-		t.Fatalf("second DialContext: %v", err)
-	}
-	conn2.Close()
-
-	if got := atomic.LoadInt64(&tunnelCount); got != 2 {
-		t.Errorf("after second pool miss: got %d tunnels, want 2", got)
+	if got := tunnelCount.Load(); got != 1 {
+		t.Fatalf("created %d HTTP/1.1 tunnels for two sequential requests, want 1", got)
 	}
 }
 
-func TestGetOrCreateTransport_TunnelNotCreatedOnCacheLookup(t *testing.T) {
-	// Verifies that merely looking up the cached transport does not call
-	// getTunnel -- tunnels are created lazily on DialContext (pool miss).
-	var tunnelCount int64
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		atomic.AddInt64(&tunnelCount, 1)
-		return newFakeTunnel(), nil
-	})
+func TestServeHTTPStreamsWithoutGlobalFlushInterval(t *testing.T) {
+	backendFlushed := make(chan struct{})
+	releaseBackend := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseBackend) }) }
+	t.Cleanup(release)
 
-	// Two cache lookups -- no DialContext calls yet.
-	_ = s.getOrCreateTransport("cluster1")
-	_ = s.getOrCreateTransport("cluster1")
-
-	if got := atomic.LoadInt64(&tunnelCount); got != 0 {
-		t.Errorf("getTunnel must not be called during cache lookup, got %d calls", got)
-	}
-}
-
-func TestServeHTTP_DifferentClustersGetDifferentTransports(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
-	})
-
-	ta := s.getOrCreateTransport("cluster-a")
-	tb := s.getOrCreateTransport("cluster-b")
-
-	if ta == tb {
-		t.Error("different clusters must have different cached transports")
-	}
-	if s.getOrCreateTransport("cluster-a") != ta {
-		t.Error("second lookup for cluster-a must return the same transport")
-	}
-	if s.getOrCreateTransport("cluster-b") != tb {
-		t.Error("second lookup for cluster-b must return the same transport")
-	}
-}
-
-// --- ServeHTTP upgrade-detection tests ---
-
-func TestServeHTTP_NonUpgradeUsesTransportCache(t *testing.T) {
-	// Verifies that non-upgrade requests use the cached transport (getTunnel is
-	// not called just from cache lookup -- only on a DialContext pool miss).
-	var tunnelCount int64
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		atomic.AddInt64(&tunnelCount, 1)
-		return newFakeTunnel(), nil
-	})
-
-	// Seeding the cache must not trigger getTunnel.
-	preexisting := s.getOrCreateTransport("mycluster")
-	if atomic.LoadInt64(&tunnelCount) != 0 {
-		t.Fatal("getTunnel must not be called on cache seed")
-	}
-
-	// A second lookup must return the same transport.
-	if s.getOrCreateTransport("mycluster") != preexisting {
-		t.Error("second cache lookup returned a different transport")
-	}
-}
-
-func TestServeHTTP_UpgradeRequestBypassesTransportCache(t *testing.T) {
-	// Start a TLS backend that just returns 200.
-	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
+	backend, roots := newTLSBackend(t, testClusterName, true, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "first event\n")
+		w.(http.Flusher).Flush()
+		close(backendFlushed)
+		<-releaseBackend
+		_, _ = io.WriteString(w, "second event\n")
 	}))
-	t.Cleanup(backend.Close)
+	server, _ := newProxyToBackend(t, roots, backend.Listener.Addr().String(), true)
+	proxy := httptest.NewServer(server)
+	t.Cleanup(proxy.Close)
 
-	rootCAs := backend.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs
-	setupServiceProxyRootCA(t, rootCAs)
+	line := make(chan string, 1)
+	errResult := make(chan error, 1)
+	go func() {
+		response, err := proxy.Client().Get(proxy.URL + kubeAPIPath(testClusterName))
+		if err != nil {
+			errResult <- err
+			return
+		}
+		defer response.Body.Close()
+		firstLine, err := bufio.NewReader(response.Body).ReadString('\n')
+		if err != nil {
+			errResult <- err
+			return
+		}
+		line <- firstLine
+	}()
 
-	var tunnelCount int64
-	s := newTestUserServer(func(ctx context.Context) (konnectivity.Tunnel, error) {
-		atomic.AddInt64(&tunnelCount, 1)
-		return newDialingFakeTunnel(backend.Listener.Addr().String()), nil
-	})
+	waitForSignal(t, backendFlushed, "backend to flush its first event")
+	select {
+	case got := <-line:
+		if got != "first event\n" {
+			t.Fatalf("first streamed line = %q", got)
+		}
+	case err := <-errResult:
+		t.Fatalf("read stream: %v", err)
+	case <-time.After(3 * time.Second):
+		release()
+		t.Fatal("first event was not delivered while the backend response remained open")
+	}
+	release()
+}
 
-	// Seed the cache for this cluster.
-	preexisting := s.getOrCreateTransport("mycluster")
+func TestServeHTTPUpgradeUsesDedicatedHTTP1Tunnel(t *testing.T) {
+	backendProtocol := make(chan string, 1)
+	backend, roots := newTLSBackend(t, testClusterName, true, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		backendProtocol <- request.Proto
+		connection, readWriter, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("backend hijack: %v", err)
+			return
+		}
+		defer connection.Close()
+		_, _ = fmt.Fprintf(readWriter, "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n")
+		if err := readWriter.Flush(); err != nil {
+			t.Errorf("backend flush upgrade: %v", err)
+			return
+		}
+		message, err := readWriter.ReadString('\n')
+		if err != nil {
+			t.Errorf("backend read upgraded connection: %v", err)
+			return
+		}
+		_, _ = fmt.Fprintf(readWriter, "echo: %s", message)
+		_ = readWriter.Flush()
+	}))
+	server, tunnelCount := newProxyToBackend(t, roots, backend.Listener.Addr().String(), true)
+	proxy := httptest.NewServer(server)
+	t.Cleanup(proxy.Close)
 
-	// Send an upgrade request.
-	req := httptest.NewRequest(http.MethodGet,
-		"/mycluster/api/v1/namespaces/default/pods/pod/exec", nil)
-	req.Header.Set("Connection", "Upgrade")
-	req.Header.Set("Upgrade", "SPDY/3.1")
-	rr := httptest.NewRecorder()
-
-	s.ServeHTTP(rr, req)
-
-	// getTunnel must have been called for the upgrade request (bypass path).
-	if got := atomic.LoadInt64(&tunnelCount); got == 0 {
-		t.Error("getTunnel must be called for upgrade requests")
+	address := strings.TrimPrefix(proxy.URL, "http://")
+	connection, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatalf("dial user-server: %v", err)
+	}
+	defer connection.Close()
+	if err := connection.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	_, _ = fmt.Fprintf(connection,
+		"GET %s HTTP/1.1\r\nHost: %s\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n",
+		kubeAPIPath(testClusterName), address,
+	)
+	reader := bufio.NewReader(connection)
+	status, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read upgrade status: %v", err)
+	}
+	if status != "HTTP/1.1 101 Switching Protocols\r\n" {
+		t.Fatalf("upgrade status = %q", status)
+	}
+	for {
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read upgrade header: %v", err)
+		}
+		if header == "\r\n" {
+			break
+		}
+	}
+	_, _ = io.WriteString(connection, "ping\n")
+	echo, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read upgraded response: %v", err)
+	}
+	if echo != "echo: ping\n" {
+		t.Fatalf("upgraded response = %q", echo)
 	}
 
-	// The cached transport must be unchanged.
-	if s.getOrCreateTransport("mycluster") != preexisting {
-		t.Error("upgrade request must not replace the cached transport")
+	if protocol := <-backendProtocol; protocol != "HTTP/1.1" {
+		t.Fatalf("upgrade backend protocol = %q, want HTTP/1.1", protocol)
+	}
+	if got := tunnelCount.Load(); got != 1 {
+		t.Fatalf("upgrade created %d tunnels, want 1", got)
+	}
+	server.transportPool.mu.Lock()
+	cached := len(server.transportPool.transports)
+	server.transportPool.mu.Unlock()
+	if cached != 0 {
+		t.Fatalf("upgrade populated the shared transport cache with %d entries", cached)
 	}
 }
 
-func TestGetOrCreateTransport_HTTP2DisabledViaFlag(t *testing.T) {
-	s := newTestUserServer(func(_ context.Context) (konnectivity.Tunnel, error) {
-		return newFakeTunnel(), nil
+func newTestUserServer(
+	roots *x509.CertPool,
+	getTunnel func(context.Context) (konnectivity.Tunnel, error),
+) *userServer {
+	server := newUserServer()
+	server.serviceProxyRootCA = roots
+	server.serviceAllowlist = &ServiceAllowlist{}
+	server.getTunnel = getTunnel
+	return server
+}
+
+func newProxyToBackend(
+	t *testing.T,
+	roots *x509.CertPool,
+	backendAddress string,
+	enableHTTP2 bool,
+) (*userServer, *atomic.Int64) {
+	t.Helper()
+	tunnelCount := &atomic.Int64{}
+	server := newTestUserServer(roots, func(context.Context) (konnectivity.Tunnel, error) {
+		tunnelCount.Add(1)
+		return newDialingTunnel(backendAddress), nil
 	})
-	s.enableHTTP2 = false
+	server.enableHTTP2 = enableHTTP2
+	server.transportPool.allow(testClusterName)
+	return server, tunnelCount
+}
 
-	transport := s.getOrCreateTransport("cluster1")
-
-	if transport.ForceAttemptHTTP2 {
-		t.Error("ForceAttemptHTTP2 must be false when --enable-http2=false")
+func newTLSBackend(
+	t *testing.T,
+	clusterName string,
+	enableHTTP2 bool,
+	handler http.Handler,
+) (*httptest.Server, *x509.CertPool) {
+	t.Helper()
+	target, err := url.Parse(serviceProxyURL(clusterName))
+	if err != nil {
+		t.Fatalf("parse service proxy URL: %v", err)
 	}
+	certificatePEM, keyPEM, err := certutil.GenerateSelfSignedCertKey(target.Hostname(), nil, nil)
+	if err != nil {
+		t.Fatalf("generate backend certificate: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certificatePEM, keyPEM)
+	if err != nil {
+		t.Fatalf("parse backend certificate: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certificatePEM) {
+		t.Fatal("add backend CA certificate")
+	}
+
+	backend := httptest.NewUnstartedServer(handler)
+	backend.EnableHTTP2 = enableHTTP2
+	backend.TLS = &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+	}
+	backend.StartTLS()
+	t.Cleanup(backend.Close)
+	return backend, roots
+}
+
+func getResponse(t *testing.T, client *http.Client, requestURL string) string {
+	t.Helper()
+	response, err := client.Get(requestURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", requestURL, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%q", response.StatusCode, http.StatusOK, body)
+	}
+	return string(body)
+}
+
+func kubeAPIPath(clusterName string) string {
+	return "/" + clusterName + "/api/v1/namespaces/default/configmaps"
+}
+
+func serviceProxyPath(clusterName string) string {
+	return "/" + clusterName + "/api/v1/namespaces/default/services/http:example:80/proxy-service/"
 }


### PR DESCRIPTION
## Problem

The user-server creates a new gRPC tunnel (full TCP+TLS negotiation) for
every incoming HTTP request, regardless of whether an existing tunnel to
the same cluster is idle. Under load this generates large numbers of
short-lived Proxy() handlers on the ANP proxy-server, causing:

- Lock contention on shared state (established map, PendingDial)
- Channel backpressure: `"Receive channel from agent/frontend is full"`
- Stream cancellations: `"Stream read from frontend cancelled"`
- Cleanup races: `"could not get frontend client for closing"`

## Fix

### Commit 1: Cache one http.Transport per managed cluster

Replace the per-request transport creation with a cached transport per
cluster stored in a sync.Map. Go's http.Transport retains the underlying
net.Conn (the konnectivity tunnel) in its idle pool after each request
completes. Subsequent requests reuse the idle connection without creating
a new tunnel.

Transport pool uses hardcoded defaults appropriate for HTTP/2 multiplexing:
- maxIdleConnsPerHost=10
- maxConnsPerHost=10
- idleConnTimeout=90s

### Commit 2: Enable HTTP/2 and streaming flush on cached transport

With HTTP/2 enabled, concurrent REST API requests to the same cluster
multiplex over a single connection via HTTP/2 streams. The proxy-server
sees O(user-server replicas) Proxy() handlers per cluster regardless of
request concurrency, instead of one handler per concurrent request.

Upgrade requests (SPDY/WebSocket, e.g. kubectl exec, console sessions)
bypass the cached transport and use a dedicated HTTP/1.1 tunnel -- SPDY
compatibility is not affected.

If HTTP/2 negotiation fails, the transport falls back to HTTP/1.1
automatically, and MaxConnsPerHost acts as a safety net.

A `--enable-http2` flag (default true) is provided to disable HTTP/2 if
needed for compatibility.

`FlushInterval = -1` is set on the reverse proxy so that chunked/streaming
responses (e.g. Kubernetes watch requests using chunked transfer encoding)
are flushed to the client immediately instead of being buffered. Without
this, watch events sit in the reverse proxy buffer and downstream proxies
(e.g. HAProxy routes) close the connection after their idle timeout.

## Notes

- No changes to konnectivity client, ANP proxy-server, Helm charts, or CRDs
- The service-proxy already accepts HTTP/2 inbound (Go's http.Server enables
  it automatically with TLS)